### PR TITLE
Ensure index is saved on project addition

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -186,9 +186,15 @@ func (idx *Index) SaveIndex() error {
 // AddProject appends a project to the given product and writes its TOML.
 // projectID = len(product.Projects) + 1
 // Collisions on disk are acceptable by your policy (we overwrite TOML).
-func (prd *ProductType) AddProject(projectName string) error {
+//
+// idx must be the index containing this product so the index can be
+// persisted after adding the project.
+func (prd *ProductType) AddProject(idx *Index, projectName string) error {
 	if projectName == "" {
 		return errors.New("project name cannot be empty")
+	}
+	if idx == nil {
+		return errors.New("index cannot be nil")
 	}
 
 	newPrjID := len(prd.Projects) + 1
@@ -211,6 +217,9 @@ func (prd *ProductType) AddProject(projectName string) error {
 
 	// Update in-memory index and persist
 	prd.Projects = append(prd.Projects, addedproject)
+	if err := idx.SaveIndex(); err != nil {
+		return fmt.Errorf("Error Save-ing Index, AddProject function: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- persist `index.toml` whenever a project is added by passing the index into `AddProject`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a87734b3e8832b9d4b2b62cd91e4a5