### PR TITLE
Ensure project directory exists before saving TOML

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -227,6 +227,9 @@ func (prd *ProductType) AddProject(idx *Index, projectName string) error {
 func (prj *ProjectType) SaveProject() error {
 	// Persist index
 	prjDir := projectDir(prj.ProductID, prj.ID)
+	if err := os.MkdirAll(prjDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir project dir: %w", err)
+	}
 	tomlPath := filepath.Join(prjDir, projectTOML)
 
 	if err := writeTOML(tomlPath, prj); err != nil {


### PR DESCRIPTION
## Summary
- Create the project directory in `SaveProject` using `os.MkdirAll` before writing the TOML file.

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a88210c1f4832b9ef904852e5d923e