### PR TITLE
refactor: omit project data from index

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ PMFS (Product Manager File System) is a lightweight backend for storing and orga
 ## Directory Structure
 
 The backend stores its data in a folder called `database`. Inside it, each product gets its own subdirectory and keeps an `index.toml` of projects.
+The index contains only lightweight metadata (project IDs and names); each project's detailed data lives in its own `project.toml` file.
 
 ```mermaid
 graph TD


### PR DESCRIPTION
## Summary
- avoid storing heavy ProjectData in index by skipping field via struct tag
- streamline index persistence and still write/read full project files
- document that index contains only lightweight project metadata

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a86aa66598832b8f62e09ddfd5cc31