### PR TITLE
Allow configurable base data directory

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -21,19 +21,42 @@ import (
 // -----------------------------------------------------------------------------
 
 const (
-	databaseDir   = "database"
 	productsDir   = "products"
 	indexFilename = "index.toml"
 	projectTOML   = "project.toml"
+	envBaseDir    = "PMFS_BASEDIR"
 )
 
 var (
-	baseProductsDir = filepath.Join(databaseDir, productsDir)
-	indexPath       = filepath.Join(baseProductsDir, indexFilename)
+	baseDir         = defaultBaseDir()
+	baseProductsDir string
+	indexPath       string
 
 	ErrProductNotFound = errors.New("product not found")
 	ErrProjectNotFound = errors.New("project not found")
 )
+
+func init() {
+	setBaseDir(baseDir)
+}
+
+func defaultBaseDir() string {
+	if dir := os.Getenv(envBaseDir); dir != "" {
+		return dir
+	}
+	return "database"
+}
+
+// SetBaseDir overrides the base data directory and updates internal paths.
+func SetBaseDir(dir string) {
+	baseDir = dir
+	setBaseDir(dir)
+}
+
+func setBaseDir(dir string) {
+	baseProductsDir = filepath.Join(dir, productsDir)
+	indexPath = filepath.Join(baseProductsDir, indexFilename)
+}
 
 // -----------------------------------------------------------------------------
 // Memory model

--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -1,0 +1,46 @@
+package PMFS
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureLayoutUsesBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	SetBaseDir(dir)
+	if err := EnsureLayout(); err != nil {
+		t.Fatalf("EnsureLayout: %v", err)
+	}
+	p := filepath.Join(dir, productsDir, indexFilename)
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("index not created at %s: %v", p, err)
+	}
+}
+
+func TestAddProductAndProject(t *testing.T) {
+	dir := t.TempDir()
+	SetBaseDir(dir)
+	if err := EnsureLayout(); err != nil {
+		t.Fatalf("EnsureLayout: %v", err)
+	}
+	idx, err := LoadIndex()
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if err := idx.AddProduct("prod1"); err != nil {
+		t.Fatalf("AddProduct: %v", err)
+	}
+	prodDir := filepath.Join(dir, productsDir, "1", "projects")
+	if _, err := os.Stat(prodDir); err != nil {
+		t.Fatalf("product dir missing: %v", err)
+	}
+	prd := &idx.Products[0]
+	if err := prd.AddProject(&idx, "prj1"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	prjToml := filepath.Join(dir, productsDir, "1", "projects", "1", projectTOML)
+	if _, err := os.Stat(prjToml); err != nil {
+		t.Fatalf("project toml missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow base data directory to be overridden through `PMFS_BASEDIR` or `SetBaseDir`
- use temporary directories in tests to isolate filesystem state

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7ac1574832b96369a7ae3a8d90c