### PR TITLE
docs: fix README usage for PMFS package

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -1,0 +1,37 @@
+# PMFS Functions
+
+This document lists all exported functions in the PMFS package and what they do.
+
+## EnsureLayout
+Creates base folder structure and ensures `index.toml` exists.
+
+## LoadIndex
+Reads `index.toml` into the in-memory index model.
+
+## (*Index) AddProduct
+Appends a product to the index and creates its directory skeleton.
+
+## (*Index) SaveIndex
+Writes the in-memory index to `index.toml`.
+
+## (*ProductType) AddProject
+Adds a new project to a product and persists the change to disk.
+
+## (*ProjectType) SaveProject
+Writes the project's data to its `project.toml` file.
+
+## (*ProjectType) LoadProject
+Loads a project's data from its `project.toml` file.
+
+## (*ProductType) LoadProjects
+Loads all projects for a given product.
+
+## (*Index) LoadAllProjects
+Loads all projects for all products in the index.
+
+## (*ProjectType) IngestInputDir
+Scans a directory and ingests each file as an attachment.
+
+## (*ProjectType) AddAttachmentFromInput
+Moves a single file into the project's attachments and records minimal metadata.
+

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ go build ./...
 ```mermaid
 sequenceDiagram
     participant Dev as Developer
-    participant Store as storage package
+    participant PMFS as PMFS package
 
-    Dev->>Store: EnsureLayout()
-    Store-->>Dev: create base folders
-    Dev->>Store: LoadIndex()
-    Store-->>Dev: read index.toml
-    Dev->>Store: AddProduct/AddProject
-    Store-->>Dev: write project.toml
+    Dev->>PMFS: EnsureLayout()
+    PMFS-->>Dev: create base folders
+    Dev->>PMFS: LoadIndex()
+    PMFS-->>Dev: read index.toml
+    Dev->>PMFS: AddProduct/AddProject
+    PMFS-->>Dev: write project.toml
 ```
 
 ## Example Usage
@@ -73,14 +73,31 @@ package main
 import (
     "fmt"
 
-    "github.com/rjboer/PMFS/storage"
+    PMFS "github.com/rjboer/PMFS"
 )
 
 func main() {
-    if err := storage.EnsureLayout(); err != nil {
+    if err := PMFS.EnsureLayout(); err != nil {
         panic(err)
     }
-    idx, _ := storage.LoadIndex()
+    idx, _ := PMFS.LoadIndex()
     fmt.Println(idx.Products)
 }
 ```
+
+## Available Functions
+
+- `EnsureLayout()`
+- `LoadIndex()`
+- `(*Index) AddProduct(name string) error`
+- `(*Index) SaveIndex() error`
+- `(*ProductType) AddProject(idx *Index, projectName string) error`
+- `(*ProjectType) SaveProject() error`
+- `(*ProjectType) LoadProject() error`
+- `(*ProductType) LoadProjects() error`
+- `(*Index) LoadAllProjects() error`
+- `(*ProjectType) IngestInputDir(inputDir string) ([]Attachment, error)`
+- `(*ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attachment, error)`
+
+See [FUNCTIONS.md](FUNCTIONS.md) for detailed descriptions.
+


### PR DESCRIPTION
## Summary
- fix README example to import `github.com/rjboer/PMFS`
- update documentation to call `PMFS` package functions
- adjust sequence diagram to reference the `PMFS` package
- list exported PMFS functions in README and link to detailed descriptions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7a937a0832b8cff471536ef72b4