### PR TITLE
Add analysed flag to attachments

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -131,6 +131,7 @@ type Attachment struct {
 	RelPath  string    `json:"rel_path" toml:"rel_path"` // e.g. "attachments/3/spec.pdf"
 	Mimetype string    `json:"mimetype" toml:"mimetype"` // e.g. "application/pdf"
 	AddedAt  time.Time `json:"added_at" toml:"added_at"`
+	Analyzed bool      `json:"analysed" toml:"analysed"`
 }
 
 // ChangeLog records a change made to a requirement.
@@ -552,6 +553,7 @@ func (prj *ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attac
 		RelPath:  rel,
 		Mimetype: mt,
 		AddedAt:  time.Now(),
+		Analyzed: false,
 	}
 	prj.D.Attachments = append(prj.D.Attachments, att)
 

--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -118,6 +118,10 @@ func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 		t.Fatalf("AddAttachmentFromInput: %v", err)
 	}
 
+	if att.Analyzed {
+		t.Fatalf("expected Analyzed to default to false")
+	}
+
 	dst := filepath.Join(dir, productsDir, "1", "projects", "1", "attachments", "1", fname)
 	if _, err := os.Stat(dst); err != nil {
 		t.Fatalf("attachment not moved: %v", err)
@@ -135,6 +139,9 @@ func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 	}
 	if len(prjReload.D.Attachments) != 1 || prjReload.D.Attachments[0].Filename != fname {
 		t.Fatalf("attachment not persisted: %#v", prjReload.D.Attachments)
+	}
+	if prjReload.D.Attachments[0].Analyzed {
+		t.Fatalf("Analyzed flag not persisted as false: %#v", prjReload.D.Attachments[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- track whether attachments have been analysed via new `Analyzed` field
- set `Analyzed` to false on ingestion and persist value in project files
- verify default false state of `Analyzed` in attachment workflow tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8bdd5266c832b8140530eae6c04f2