### PR TITLE
Add Gemini attachment analysis test with real/mocked behavior

### DIFF
--- a/pmfs/llm/gemini/gemini_test.go
+++ b/pmfs/llm/gemini/gemini_test.go
@@ -1,13 +1,17 @@
 package gemini
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -148,5 +152,138 @@ func TestClientFuncAnalyzeAttachment(t *testing.T) {
 	}
 	if len(reqs) != 1 || reqs[0].ID != 1 || reqs[0].Name != "R" {
 		t.Fatalf("unexpected requirements: %#v", reqs)
+	}
+}
+
+type mockGeminiTransport struct {
+	mu     sync.Mutex
+	nextID int
+	files  map[string]string
+}
+
+func newMockGeminiTransport() *mockGeminiTransport {
+	return &mockGeminiTransport{files: make(map[string]string), nextID: 1}
+}
+
+func (m *mockGeminiTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, "/upload/") {
+		boundary := strings.TrimPrefix(req.Header.Get("Content-Type"), "multipart/form-data; boundary=")
+		mr := multipart.NewReader(req.Body, boundary)
+		var fname string
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if part.FormName() == "file" {
+				fname = part.FileName()
+				break
+			}
+		}
+		m.mu.Lock()
+		id := fmt.Sprintf("files/%d", m.nextID)
+		m.nextID++
+		var resp string
+		switch {
+		case strings.Contains(fname, "spec1"):
+			resp = `[{"id":1,"name":"Spec1"}]`
+		case strings.Contains(fname, "spec2"):
+			resp = `[{"id":1,"name":"Spec2"}]`
+		default:
+			resp = ""
+		}
+		m.files[id] = resp
+		m.mu.Unlock()
+
+		rec := httptest.NewRecorder()
+		rec.WriteString(fmt.Sprintf(`{"file":{"name":"%s","mimeType":"text/plain"}}`, id))
+		return rec.Result(), nil
+	}
+	if strings.Contains(req.URL.Path, ":generateContent") {
+		var body struct {
+			Contents []struct {
+				Parts []struct {
+					FileData struct {
+						FileURI string `json:"file_uri"`
+					} `json:"file_data"`
+				} `json:"parts"`
+			} `json:"contents"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			return nil, err
+		}
+		id := body.Contents[0].Parts[0].FileData.FileURI
+		m.mu.Lock()
+		resp, ok := m.files[id]
+		m.mu.Unlock()
+		rec := httptest.NewRecorder()
+		if !ok {
+			rec.Code = http.StatusBadRequest
+			rec.Body = bytes.NewBufferString("unknown file")
+			return rec.Result(), nil
+		}
+		if resp == "" {
+			rec.Code = http.StatusInternalServerError
+			rec.Body = bytes.NewBufferString("bad file")
+			return rec.Result(), nil
+		}
+		rec.WriteString(fmt.Sprintf(`{"candidates":[{"content":{"parts":[{"text":%q}]}}]}`, resp))
+		return rec.Result(), nil
+	}
+	return nil, fmt.Errorf("unexpected path %s", req.URL.Path)
+}
+
+func sameRequirements(a, b []Requirement) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ba, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return bytes.Equal(ba, bb)
+}
+
+func TestRESTClientAnalyzeAttachmentReal(t *testing.T) {
+	base := filepath.Join("..", "..", "..", "testdata")
+	p1 := filepath.Join(base, "spec1.txt")
+	p2 := filepath.Join(base, "spec2.txt")
+
+	key := os.Getenv("GEMINI_API_KEY")
+	if key != "" && key != "test-key" {
+		c := &RESTClient{}
+		r1, err := c.AnalyzeAttachment(p1)
+		if err != nil {
+			t.Fatalf("AnalyzeAttachment(spec1): %v", err)
+		}
+		t.Logf("real Gemini returned for spec1: %#v", r1)
+		r2, err := c.AnalyzeAttachment(p2)
+		if err != nil {
+			t.Fatalf("AnalyzeAttachment(spec2): %v", err)
+		}
+		t.Logf("real Gemini returned for spec2: %#v", r2)
+		if sameRequirements(r1, r2) {
+			t.Fatalf("expected different requirements for distinct documents")
+		}
+		return
+	}
+
+	t.Setenv("GEMINI_API_KEY", "")
+	mt := newMockGeminiTransport()
+	c := &RESTClient{APIKey: "k", HTTPClient: &http.Client{Transport: mt}}
+	r1, err := c.AnalyzeAttachment(p1)
+	if err != nil {
+		t.Fatalf("AnalyzeAttachment(spec1): %v", err)
+	}
+	t.Logf("mock Gemini returned for spec1: %#v", r1)
+	r2, err := c.AnalyzeAttachment(p2)
+	if err != nil {
+		t.Fatalf("AnalyzeAttachment(spec2): %v", err)
+	}
+	t.Logf("mock Gemini returned for spec2: %#v", r2)
+	if sameRequirements(r1, r2) {
+		t.Fatalf("expected different requirements for mock documents")
+	}
+
+	if _, err := c.AnalyzeAttachment(filepath.Join(base, "sources.txt")); err == nil {
+		t.Fatalf("expected error for unsupported document")
 	}
 }


### PR DESCRIPTION
## Summary
- add mock Gemini server that returns distinct requirement lists and non-JSON errors
- add TestRESTClientAnalyzeAttachmentReal which calls real Gemini when API key provided or the mock otherwise
- log requirement lists from real/mocked runs for visibility

## Testing
- `go test ./...`
- `go test ./pmfs/llm/gemini -run TestRESTClientAnalyzeAttachmentReal -v`


------
https://chatgpt.com/codex/tasks/task_e_68a8e5e07804832b89c1ed5d2146dbaf