### PR TITLE
Allow Requirement ID to parse string numbers

### DIFF
--- a/pmfs/llm/gemini/gemini.go
+++ b/pmfs/llm/gemini/gemini.go
@@ -17,7 +17,7 @@ import (
 
 // Requirement represents a potential requirement returned by Gemini.
 type Requirement struct {
-	ID          int    `json:"id"`
+	ID          int    `json:"id,string"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }

--- a/pmfs/llm/gemini/gemini_test.go
+++ b/pmfs/llm/gemini/gemini_test.go
@@ -84,6 +84,17 @@ func TestClientFuncAnalyzeAttachment(t *testing.T) {
 	}
 }
 
+func TestRequirementUnmarshalStringID(t *testing.T) {
+	data := []byte(`[{"id":"42","name":"N","description":"D"}]`)
+	var reqs []Requirement
+	if err := json.Unmarshal(data, &reqs); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].ID != 42 {
+		t.Fatalf("unexpected requirements: %#v", reqs)
+	}
+}
+
 func sameRequirements(a, b []Requirement) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary
- allow `Requirement.ID` to decode numeric strings
- add test covering string-based IDs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8ff5e2c88832bb8e5aa8bf0f392ac