### PR TITLE
Add Analyse methods for attachments and requirements

### DIFF
--- a/examples/analyse/main.go
+++ b/examples/analyse/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	PMFS "github.com/rjboer/PMFS"
+	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+// This example demonstrates analysing an attachment with a role-specific question.
+func main() {
+	// Stub Gemini client so the example runs without external calls.
+	stub := gemini.ClientFunc{
+		AskFunc: func(prompt string) (string, error) {
+			if strings.Contains(strings.ToLower(prompt), "answer yes or no only") {
+				return "Yes", nil
+			}
+			return "stub response", nil
+		},
+	}
+	prev := gemini.SetClient(stub)
+	defer gemini.SetClient(prev)
+
+	PMFS.SetBaseDir(".")
+	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
+	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
+
+	pass, follow, err := att.Analyse("product_manager", "1", &prj)
+	if err != nil {
+		log.Fatalf("Analyse: %v", err)
+	}
+	fmt.Printf("Pass: %v\n", pass)
+	if follow != "" {
+		fmt.Printf("Follow-up: %s\n", follow)
+	}
+}

--- a/pmfs/llm/gemini/gemini.go
+++ b/pmfs/llm/gemini/gemini.go
@@ -76,12 +76,17 @@ func (f ClientFunc) Ask(prompt string) (string, error) {
 	return f.AskFunc(prompt)
 }
 
-var client Client = &RESTClient{}
+// DefaultClient is the package's default Gemini client.
+var (
+	DefaultClient Client = &RESTClient{}
+	client        Client = DefaultClient
+)
 
 // SetClient replaces the package's client, returning the previous one.
 func SetClient(c Client) Client {
 	old := client
 	client = c
+	DefaultClient = c
 	return old
 }
 


### PR DESCRIPTION
## Summary
- add Analyse method on Requirement to run role-specific questions
- add Analyse on Attachment to read file content and query Gemini
- expose gemini.DefaultClient for consumers and add analyse example

## Testing
- `GEMINI_API_KEY= go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aadbb52c5c832bb7740e030f12be05