### PR TITLE
Register quality_gate role for gates

### DIFF
--- a/pmfs/llm/gates/evaluate.go
+++ b/pmfs/llm/gates/evaluate.go
@@ -1,11 +1,8 @@
 package gates
 
 import (
-	"fmt"
-
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 	"github.com/rjboer/PMFS/pmfs/llm/interact"
-	"github.com/rjboer/PMFS/pmfs/llm/prompts"
 )
 
 // Result holds the outcome of a gate evaluation.
@@ -24,9 +21,7 @@ func Evaluate(client gemini.Client, gateIDs []string, text string) ([]Result, er
 		if err != nil {
 			return nil, err
 		}
-		template := fmt.Sprintf("Given the requirement %%s, %s Answer yes or no.", g.Question)
-		prompts.SetTestPrompts([]prompts.Prompt{{ID: g.ID, Template: template, FollowUp: g.FollowUp}})
-		pass, follow, err := interact.RunQuestion(client, "test", g.ID, text)
+		pass, follow, err := interact.RunQuestion(client, "quality_gate", g.ID, text)
 		if err != nil {
 			return nil, err
 		}

--- a/pmfs/llm/gates/gate.go
+++ b/pmfs/llm/gates/gate.go
@@ -1,6 +1,10 @@
 package gates
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/rjboer/PMFS/pmfs/llm/prompts"
+)
 
 // Gate represents a Yes/No gate used to evaluate requirements.
 type Gate struct {
@@ -9,9 +13,20 @@ type Gate struct {
 	FollowUp string
 }
 
-var registry = map[string]Gate{}
+var (
+	registry    = map[string]Gate{}
+	gatePrompts []prompts.Prompt
+)
 
-func register(g Gate) { registry[g.ID] = g }
+func register(g Gate) {
+	registry[g.ID] = g
+	template := fmt.Sprintf("Given the requirement %%s, %s Answer yes or no.", g.Question)
+	gatePrompts = append(gatePrompts, prompts.Prompt{ID: g.ID, Template: template, FollowUp: g.FollowUp})
+}
+
+func init() {
+	prompts.RegisterRole("quality_gate", gatePrompts)
+}
 
 // GetGate returns the gate with the given ID or an error if it doesn't exist.
 func GetGate(id string) (Gate, error) {


### PR DESCRIPTION
## Summary
- collect gate prompts and register them under `quality_gate` role
- evaluate gates using the `quality_gate` role instead of test prompts

## Testing
- `go test ./pmfs/llm/gates -run TestEvaluate -count=1` *(failed: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68aae8f84690832b8d5cef7dd38ff145