### PR TITLE
Add gate evaluation support to requirements

### DIFF
--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	PMFS "github.com/rjboer/PMFS"
+	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+// This example demonstrates evaluating a requirement against a gate.
+func main() {
+	// Stub Gemini client so the example runs without external calls.
+	stub := gemini.ClientFunc{
+		AskFunc: func(prompt string) (string, error) {
+			return "Yes", nil
+		},
+	}
+	prev := gemini.SetClient(stub)
+	defer gemini.SetClient(prev)
+
+	req := PMFS.Requirement{Description: "The system shall be user friendly."}
+	if err := req.EvaluateGates([]string{"clarity-form-1"}); err != nil {
+		log.Fatalf("EvaluateGates: %v", err)
+	}
+	for _, gr := range req.GateResults {
+		fmt.Printf("Gate %s passed: %v\n", gr.Gate.ID, gr.Pass)
+	}
+}


### PR DESCRIPTION
## Summary
- track gate evaluation results on requirements
- add EvaluateGates helper using Gemini and gates package
- document usage with gates example

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aae8f89c18832b99c0678008c59250