### PR TITLE
feat: add default text gate evaluator

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	_ "github.com/rjboer/PMFS/internal/config"
+	"github.com/rjboer/PMFS/pmfs/llm/gates"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 	"github.com/rjboer/PMFS/pmfs/llm/interact"
 )
@@ -132,6 +133,12 @@ type Requirement struct {
 // and returns the result.
 func (r *Requirement) Analyse(role, questionID string) (bool, string, error) {
 	return interact.RunQuestion(gemini.DefaultClient, role, questionID, r.Description)
+}
+
+// EvaluateGates runs the requirement's description through the specified gates
+// using the default Gemini client.
+func (r *Requirement) EvaluateGates(gateIDs []string) ([]gates.Result, error) {
+	return gates.EvaluateText(gateIDs, r.Description)
 }
 
 // Attachment is minimal metadata about an ingested file.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ An example combining Gemini analysis, interactive questions, and gate evaluation
 go run ./examples/integration
 ```
 
+## Quality Gate Evaluation
+
+The `gates` package can assess requirement text against predefined yes/no
+checks. Use `Evaluate` when you want to provide your own Gemini client, or
+`EvaluateText` to rely on the package's default client.
+
+```go
+// Using a custom Gemini client
+res, err := gates.Evaluate(customClient, []string{"clarity-form-1"}, text)
+
+// Using the default Gemini client
+res, err = gates.EvaluateText([]string{"clarity-form-1"}, text)
+
+// From a Requirement instance
+r := PMFS.Requirement{Description: text}
+res, err = r.EvaluateGates([]string{"clarity-form-1"})
+```
+
 ## Available Functions
 
 - `EnsureLayout()`

--- a/pmfs/llm/gates/evaluate.go
+++ b/pmfs/llm/gates/evaluate.go
@@ -15,6 +15,12 @@ type Result struct {
 	FollowUp string
 }
 
+// EvaluateText runs the specified gates using the default Gemini client.
+// It evaluates the given text and returns a Result for each gate.
+func EvaluateText(gateIDs []string, text string) ([]Result, error) {
+	return Evaluate(gemini.DefaultClient, gateIDs, text)
+}
+
 // Evaluate runs the specified gates against the provided text using the Gemini client.
 // It returns a Result for each gate in the same order as gateIDs.
 func Evaluate(client gemini.Client, gateIDs []string, text string) ([]Result, error) {


### PR DESCRIPTION
## Summary
- add EvaluateText helper for default Gemini client
- expose Requirement.EvaluateGates using EvaluateText
- document Evaluate and EvaluateText in README

## Testing
- `go test ./pmfs/llm/gates`
- `go test ./...` *(fails: AddAttachmentRealAPI, RESTClientAnalyzeAttachmentReal: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aaefa34e5c832b872059a2e3e96214