### PR TITLE
Add requirement suggestion helper using Gemini

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -1,6 +1,7 @@
 package PMFS
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -145,6 +146,21 @@ func (r *Requirement) EvaluateGates(gateIDs []string) error {
 	}
 	r.GateResults = res
 	return nil
+}
+
+// SuggestOthers asks the client for related potential requirements based on
+// this requirement's description and returns them.
+func (r *Requirement) SuggestOthers(client gemini.Client) ([]Requirement, error) {
+	prompt := fmt.Sprintf("Given the requirement %q, list other potential requirements (JSON array with `name` and `description`).", r.Description)
+	resp, err := client.Ask(prompt)
+	if err != nil {
+		return nil, err
+	}
+	var reqs []Requirement
+	if err := json.Unmarshal([]byte(resp), &reqs); err != nil {
+		return nil, err
+	}
+	return reqs, nil
 }
 
 // Attachment is minimal metadata about an ingested file.

--- a/requirement_suggest_test.go
+++ b/requirement_suggest_test.go
@@ -1,0 +1,38 @@
+package PMFS
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+func TestRequirementSuggestOthers(t *testing.T) {
+	r := Requirement{Description: "System shall X"}
+	mockResp := `[{"name":"R2","description":"Desc2"},{"name":"R3","description":"Desc3"}]`
+	client := gemini.ClientFunc{AskFunc: func(prompt string) (string, error) {
+		expected := fmt.Sprintf("Given the requirement %q", r.Description)
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("unexpected prompt: %s", prompt)
+		}
+		return mockResp, nil
+	}}
+	reqs, err := r.SuggestOthers(client)
+	if err != nil {
+		t.Fatalf("SuggestOthers: %v", err)
+	}
+	if len(reqs) != 2 || reqs[0].Name != "R2" || reqs[1].Description != "Desc3" {
+		t.Fatalf("unexpected reqs: %#v", reqs)
+	}
+}
+
+func TestRequirementSuggestOthersMalformed(t *testing.T) {
+	r := Requirement{Description: "System shall X"}
+	client := gemini.ClientFunc{AskFunc: func(prompt string) (string, error) {
+		return "not json", nil
+	}}
+	if _, err := r.SuggestOthers(client); err == nil {
+		t.Fatalf("expected error for malformed response")
+	}
+}


### PR DESCRIPTION
## Summary
- add `Requirement.SuggestOthers` to query Gemini for related requirements and parse the JSON response
- cover suggestion parsing and malformed responses with unit tests

## Testing
- `GEMINI_API_KEY= go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab02c37ff8832b9eaff856910a062a