### PR TITLE
Add Gemini requirement helper and streamline examples

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -35,3 +35,6 @@ Scans a directory and ingests each file as an attachment.
 ## (*ProjectType) AddAttachmentFromInput
 Moves a single file into the project's attachments and records minimal metadata.
 
+## FromGemini
+Converts a Gemini requirement into a PMFS requirement by copying its name and description.
+

--- a/PMFS.go
+++ b/PMFS.go
@@ -147,6 +147,14 @@ func (r *Requirement) EvaluateGates(gateIDs []string) error {
 	return nil
 }
 
+// FromGemini converts a Gemini requirement to a PMFS requirement.
+func FromGemini(req gemini.Requirement) Requirement {
+	return Requirement{
+		Name:        req.Name,
+		Description: req.Description,
+	}
+}
+
 // Attachment is minimal metadata about an ingested file.
 type Attachment struct {
 	ID       int       `json:"id" toml:"id"`
@@ -165,10 +173,7 @@ func (att *Attachment) Analyze(prj *ProjectType) error {
 		return err
 	}
 	for _, r := range reqs {
-		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, Requirement{
-			Name:        r.Name,
-			Description: r.Description,
-		})
+		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, FromGemini(r))
 	}
 	att.Analyzed = true
 	return nil

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ go run ./examples/full
 - `(*Index) LoadAllProjects() error`
 - `(*ProjectType) IngestInputDir(inputDir string) ([]Attachment, error)`
 - `(*ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attachment, error)`
+- `FromGemini(req gemini.Requirement) Requirement`
 
 See [FUNCTIONS.md](FUNCTIONS.md) for detailed descriptions.
 

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -3,7 +3,7 @@
 This example demonstrates a complete PMFS flow using the Gemini client.
 
 1. **Analyze attachment** – `gemini.AnalyzeAttachment` extracts potential requirements from `testdata/spec1.txt`.
-2. **Store requirements** – The requirements are stored in a project structure.
+2. **Store requirements** – The requirements are stored in a project structure using `PMFS.FromGemini` to convert Gemini output.
 3. **Run role questions** – Each requirement's description is posed to several roles (`product_manager`, `qa_lead`, `security_privacy_officer`) via `interact.RunQuestion`.
 4. **Evaluate gates** – Each requirement is checked against quality gates using `gates.Evaluate`.
 5. **Interpret output** – The program prints the results, including role agreement, follow-ups, and gate outcomes.

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -50,10 +50,7 @@ func main() {
 	// Store the requirements in a project structure.
 	prj := PMFS.ProjectType{}
 	for _, r := range reqs {
-		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.Requirement{
-			Name:        r.Name,
-			Description: r.Description,
-		})
+		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.FromGemini(r))
 	}
 
 	roles := []string{"product_manager", "qa_lead", "security_privacy_officer"}

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -44,10 +44,7 @@ func main() {
 
 	// Store the first requirement in a project structure.
 	prj := PMFS.ProjectType{}
-	prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.Requirement{
-		Name:        reqs[0].Name,
-		Description: reqs[0].Description,
-	})
+	prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.FromGemini(reqs[0]))
 	r := prj.D.PotentialRequirements[0]
 	fmt.Printf("Requirement: %s - %s\n", r.Name, r.Description)
 


### PR DESCRIPTION
## Summary
- add `FromGemini` helper to create PMFS requirements from Gemini output
- use `FromGemini` in integration and full examples
- document streamlined requirement conversion in example docs and function list

## Testing
- `env -u GEMINI_API_KEY go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab02e3471c832bbb4304570d7c7f5a