### PR TITLE
Clarify Gemini client defaults and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Required variables:
 - `PMFS_BASEDIR` – base directory used to store PMFS data.
 - `GEMINI_API_KEY` – API key for Gemini integrations.
 
+The default Gemini client reads `GEMINI_API_KEY` automatically. When this
+variable is set, package functions will use the live API without any
+`SetClient` call.
+
 ## Directory Structure
 
 The backend stores its data in a folder called `database`. Inside it, each product gets its own subdirectory and keeps an `index.toml` of projects.
@@ -106,6 +110,11 @@ An example demonstrating the Gemini client lives in `examples/gemini` and can be
 ```bash
 go run ./examples/gemini
 ```
+
+All Gemini-related examples replace the client with a stub so they can run
+offline. Remove those `SetClient` blocks and ensure `GEMINI_API_KEY` is set to
+call the real API. Real API flows are illustrated in `examples/gemini`,
+`examples/integration`, and `examples/full`.
 
 An example combining Gemini analysis, interactive questions, and gate evaluation lives in `examples/integration` and can be run with:
 

--- a/examples/analyse/main.go
+++ b/examples/analyse/main.go
@@ -9,9 +9,11 @@ import (
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
-// This example demonstrates analysing an attachment with a role-specific question.
+// This example demonstrates analysing an attachment with a role-specific
+// question. Remove the stub below and set GEMINI_API_KEY to use the real API.
 func main() {
 	// Stub Gemini client so the example runs without external calls.
+	// Delete this block for live API calls.
 	stub := gemini.ClientFunc{
 		AskFunc: func(prompt string) (string, error) {
 			if strings.Contains(strings.ToLower(prompt), "answer yes or no only") {

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -14,9 +14,11 @@ import (
 // storing the returned requirements, asking multiple role-specific questions
 // about each requirement, and evaluating them against quality gates. After the
 // Gemini client is configured, requirement methods can be used directly without
-// passing the client to interact or gates packages.
+// passing the client to interact or gates packages. Remove the stub below and
+// set GEMINI_API_KEY to call the real API with the default client.
 func main() {
 	// Stub the Gemini client so the example runs without external calls.
+	// Delete this block for live API calls.
 	stub := gemini.ClientFunc{
 		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
 			return []gemini.Requirement{

--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -8,9 +8,11 @@ import (
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
-// This example demonstrates evaluating a requirement against a gate.
+// This example demonstrates evaluating a requirement against a gate. Remove
+// the stub below and set GEMINI_API_KEY to query the real API.
 func main() {
 	// Stub Gemini client so the example runs without external calls.
+	// Delete this block to use the live API.
 	stub := gemini.ClientFunc{
 		AskFunc: func(prompt string) (string, error) {
 			return "Yes", nil

--- a/examples/gemini/main.go
+++ b/examples/gemini/main.go
@@ -9,7 +9,9 @@ import (
 
 // This example demonstrates using the Gemini client to analyze a document
 // and answer a free-form question. It swaps in a stub client so the example
-// runs without calling the real API.
+// runs without calling the real API. For production, remove the SetClient
+// block and ensure GEMINI_API_KEY is set; the default client will then invoke
+// Gemini directly.
 func main() {
 	prev := gemini.SetClient(gemini.ClientFunc{
 		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -13,9 +13,12 @@ import (
 // storing the returned requirement, asking a role-specific question about it,
 // and finally evaluating it against quality gates. Once the Gemini client is
 // configured, requirement methods like Analyse and EvaluateGates can be called
-// directly without additional setup.
+// directly without additional setup. Remove the stub below and set
+// GEMINI_API_KEY to exercise the real API.
 func main() {
 	// Stub the Gemini client so the example runs without external calls.
+	// Remove this block and set GEMINI_API_KEY to use the real API via
+	// the default client.
 	stub := gemini.ClientFunc{
 		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
 			return []gemini.Requirement{{ID: 1, Name: "Login", Description: "Users shall log in with email and password."}}, nil

--- a/pmfs/llm/gemini/README.md
+++ b/pmfs/llm/gemini/README.md
@@ -15,6 +15,22 @@ Its primary goal is to extract potential software requirements from uploaded doc
 | `func Ask(prompt string) (string, error)` | Convenience wrapper calling `client.Ask`. |
 | `type RESTClient` | Default client implementation using Gemini’s REST API. Important methods: `init`, `AnalyzeAttachment`, `Ask`, `upload`, `generateFile`, `generateText`, `generate`. |
 
+## Usage
+
+The package uses `RESTClient` by default. If the `GEMINI_API_KEY` environment
+variable is set, calls to `AnalyzeAttachment` and `Ask` automatically hit
+Gemini; no `SetClient` call is required for production use.
+
+`SetClient` exists so tests or other backends can inject a stub client. The
+examples in this repository do this so they can run offline. Remove the
+`SetClient` block and ensure `GEMINI_API_KEY` is defined to exercise the real
+API.
+
+Real API flows are demonstrated in
+[`examples/gemini`](../../examples/gemini),
+[`examples/integration`](../../examples/integration), and
+[`examples/full`](../../examples/full).
+
 ## Writing Your Own Backend
 
 To swap out Gemini or integrate with another service, implement the `Client` interface:


### PR DESCRIPTION
## Summary
- Document that the default Gemini REST client uses `GEMINI_API_KEY` and requires no `SetClient` call for production
- Explain that `SetClient` is mainly for test stubs and point to examples for real API usage
- Update example comments to show how to switch from stubs to the live API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab7a862e08832b88a0a93b37580f32