### PR TITLE
feat(llm): add client abstraction with default gemini backend

### DIFF
--- a/pmfs/llm/client.go
+++ b/pmfs/llm/client.go
@@ -1,0 +1,38 @@
+package llm
+
+import (
+	"os"
+
+	"github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+// Client defines the behavior needed to analyze attachments and answer prompts.
+type Client interface {
+	AnalyzeAttachment(path string) ([]gemini.Requirement, error)
+	Ask(prompt string) (string, error)
+}
+
+var (
+	// DefaultClient is the package's default LLM client.
+	DefaultClient Client = gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY"))
+	client        Client = DefaultClient
+)
+
+// SetClient replaces the package's client, returning the previous one.
+// This is intended for internal testing use only.
+func SetClient(c Client) Client {
+	old := client
+	client = c
+	DefaultClient = c
+	return old
+}
+
+// AnalyzeAttachment uploads and analyzes the file at path using the configured client.
+func AnalyzeAttachment(path string) ([]gemini.Requirement, error) {
+	return client.AnalyzeAttachment(path)
+}
+
+// Ask sends a prompt to the configured client and returns the response.
+func Ask(prompt string) (string, error) {
+	return client.Ask(prompt)
+}

--- a/pmfs/llm/gemini/gemini.go
+++ b/pmfs/llm/gemini/gemini.go
@@ -106,6 +106,12 @@ type RESTClient struct {
 	APIKey     string
 }
 
+// NewRESTClient returns a RESTClient configured with the provided API key.
+// The HTTP client will be lazily initialized on first use.
+func NewRESTClient(apiKey string) Client {
+	return &RESTClient{APIKey: apiKey}
+}
+
 func (c *RESTClient) init() error {
 	if c.HTTPClient == nil {
 		c.HTTPClient = &http.Client{Timeout: 60 * time.Second}


### PR DESCRIPTION
## Summary
- add generic `llm.Client` interface with overridable default
- expose `NewRESTClient` constructor for Gemini clients

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab85059904832b99f445c9c9e5dae9