### PR TITLE
Use llm client instead of gemini

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	_ "github.com/rjboer/PMFS/internal/config"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gates "github.com/rjboer/PMFS/pmfs/llm/gates"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 	"github.com/rjboer/PMFS/pmfs/llm/interact"
@@ -143,13 +144,13 @@ func FromGemini(req gemini.Requirement) Requirement {
 // Analyse sends the requirement description to the provided role/question pair
 // and returns the result.
 func (r *Requirement) Analyse(role, questionID string) (bool, string, error) {
-	return interact.RunQuestion(gemini.DefaultClient, role, questionID, r.Description)
+	return interact.RunQuestion(llm.DefaultClient, role, questionID, r.Description)
 }
 
 // EvaluateGates runs the specified gates against the requirement description
 // and stores the results on the requirement.
 func (r *Requirement) EvaluateGates(gateIDs []string) error {
-	res, err := gates.Evaluate(gemini.DefaultClient, gateIDs, r.Description)
+	res, err := gates.Evaluate(llm.DefaultClient, gateIDs, r.Description)
 	if err != nil {
 		return err
 	}
@@ -185,7 +186,7 @@ type Attachment struct {
 // Analyze processes the attachment with Gemini and appends proposed requirements.
 func (att *Attachment) Analyze(prj *ProjectType) error {
 	full := filepath.Join(projectDir(prj.ProductID, prj.ID), att.RelPath)
-	reqs, err := gemini.AnalyzeAttachment(full)
+	reqs, err := llm.DefaultClient.AnalyzeAttachment(full)
 	if err != nil {
 		return err
 	}
@@ -213,7 +214,7 @@ func (att *Attachment) Analyse(role, questionID string, prj *ProjectType) (bool,
 		}
 		content = string(b)
 	} else {
-		reqs, err := gemini.AnalyzeAttachment(full)
+		reqs, err := llm.DefaultClient.AnalyzeAttachment(full)
 		if err != nil {
 			return false, "", err
 		}
@@ -226,7 +227,7 @@ func (att *Attachment) Analyse(role, questionID string, prj *ProjectType) (bool,
 		}
 		content = sb.String()
 	}
-	return interact.RunQuestion(gemini.DefaultClient, role, questionID, content)
+	return interact.RunQuestion(llm.DefaultClient, role, questionID, content)
 }
 
 // ChangeLog records a change made to a requirement.

--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
@@ -87,10 +88,10 @@ func TestAddProjectWritesTomlAndUpdatesIndex(t *testing.T) {
 
 func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 	// mock Gemini client to avoid external calls
-	orig := gemini.SetClient(gemini.ClientFunc{AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
+	orig := llm.SetClient(gemini.ClientFunc{AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
 		return nil, nil
 	}})
-	defer gemini.SetClient(orig)
+	defer llm.SetClient(orig)
 
 	t.Setenv("GEMINI_API_KEY", "test-key")
 	dir := t.TempDir()
@@ -158,10 +159,10 @@ func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 
 func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {
 	mockReqs := []gemini.Requirement{{ID: 1, Name: "R1", Description: "D1"}}
-	orig := gemini.SetClient(gemini.ClientFunc{AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
+	orig := llm.SetClient(gemini.ClientFunc{AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
 		return mockReqs, nil
 	}})
-	defer gemini.SetClient(orig)
+	defer llm.SetClient(orig)
 
 	dir := t.TempDir()
 	SetBaseDir(dir)
@@ -309,10 +310,10 @@ func TestAddAttachmentRealAPI(t *testing.T) {
 
 func TestIngestInputDirProcessesAllFiles(t *testing.T) {
 
-	orig := gemini.SetClient(gemini.ClientFunc{AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
+	orig := llm.SetClient(gemini.ClientFunc{AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
 		return nil, nil
 	}})
-	defer gemini.SetClient(orig)
+	defer llm.SetClient(orig)
 
 	t.Setenv("GEMINI_API_KEY", "test-key")
 

--- a/pmfs/llm/gates/evaluate.go
+++ b/pmfs/llm/gates/evaluate.go
@@ -1,7 +1,7 @@
 package gates
 
 import (
-	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	"github.com/rjboer/PMFS/pmfs/llm/interact"
 )
 
@@ -12,9 +12,9 @@ type Result struct {
 	FollowUp string
 }
 
-// Evaluate runs the specified gates against the provided text using the Gemini client.
+// Evaluate runs the specified gates against the provided text using the LLM client.
 // It returns a Result for each gate in the same order as gateIDs.
-func Evaluate(client gemini.Client, gateIDs []string, text string) ([]Result, error) {
+func Evaluate(client llm.Client, gateIDs []string, text string) ([]Result, error) {
 	var results []Result
 	for _, id := range gateIDs {
 		g, err := GetGate(id)

--- a/pmfs/llm/interact/runquestion.go
+++ b/pmfs/llm/interact/runquestion.go
@@ -6,16 +6,16 @@ import (
 	"regexp"
 	"strings"
 
-	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	"github.com/rjboer/PMFS/pmfs/llm/prompts"
 )
 
 // RunQuestion formats the question template for a role with the provided text
-// and asks it using the supplied Gemini client. It returns true when the response
+// and asks it using the supplied LLM client. It returns true when the response
 // contains "yes". When the response contains "no" and the prompt defines a
 // follow-up question, the follow-up is sent and its response returned alongside
 // the false result.
-func RunQuestion(client gemini.Client, role, questionID, text string) (bool, string, error) {
+func RunQuestion(client llm.Client, role, questionID, text string) (bool, string, error) {
 	ps, err := prompts.GetPrompts(role)
 	if err != nil {
 		return false, "", err


### PR DESCRIPTION
## Summary
- delegate requirement analysis, gate evaluation, and attachment processing to `llm.DefaultClient`
- update interaction and gate helpers to accept generic `llm.Client`
- adapt tests to stub the new default client

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab8759cfb4832b9450b7110320991d