### PR TITLE
Add project-level LLM client

### DIFF
--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
@@ -40,7 +41,7 @@ func main() {
 	prev := gemini.SetClient(stub)
 	defer gemini.SetClient(prev)
 	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
+	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.
@@ -59,14 +60,14 @@ func main() {
 		fmt.Printf("Requirement %d: %s - %s\n", i+1, r.Name, r.Description)
 		id := strconv.Itoa(i + 1)
 		for _, role := range roles {
-			pass, follow, _ := r.Analyse(role, id)
+			pass, follow, _ := r.Analyse(&prj, role, id)
 			fmt.Printf("  %s agrees? %v\n", role, pass)
 			if follow != "" {
 				fmt.Printf("    Follow-up: %s\n", follow)
 			}
 		}
 
-		_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
+		_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
 		for _, gr := range r.GateResults {
 			fmt.Printf("  Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 		}

--- a/examples/full/main.go_old
+++ b/examples/full/main.go_old
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
@@ -48,7 +49,7 @@ func main() {
 	}
 
 	// Store the requirements in a project structure.
-	prj := PMFS.ProjectType{}
+	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
 	for _, r := range reqs {
 		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.FromGemini(r))
 	}
@@ -61,14 +62,14 @@ func main() {
 		fmt.Printf("Requirement %d: %s - %s\n", i+1, r.Name, r.Description)
 		id := strconv.Itoa(i + 1)
 		for _, role := range roles {
-			pass, follow, _ := r.Analyse(role, id)
+			pass, follow, _ := r.Analyse(&prj, role, id)
 			fmt.Printf("  %s agrees? %v\n", role, pass)
 			if follow != "" {
 				fmt.Printf("    Follow-up: %s\n", follow)
 			}
 		}
 
-		_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
+		_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
 		for _, gr := range r.GateResults {
 			fmt.Printf("  Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 		}

--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	PMFS "github.com/rjboer/PMFS"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
@@ -22,7 +23,8 @@ func main() {
 	defer gemini.SetClient(prev)
 
 	req := PMFS.Requirement{Description: "The system shall be user friendly."}
-	if err := req.EvaluateGates([]string{"clarity-form-1"}); err != nil {
+	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
+	if err := req.EvaluateGates(&prj, []string{"clarity-form-1"}); err != nil {
 		log.Fatalf("EvaluateGates: %v", err)
 	}
 	for _, gr := range req.GateResults {

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
@@ -36,7 +37,7 @@ func main() {
 	prev := gemini.SetClient(stub)
 	defer gemini.SetClient(prev)
 	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
+	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.
@@ -53,13 +54,13 @@ func main() {
 
 	// With the client configured above, the requirement can query roles and
 	// evaluate gates directly.
-	pass, follow, _ := r.Analyse("qa_lead", "1")
+	pass, follow, _ := r.Analyse(&prj, "qa_lead", "1")
 	fmt.Printf("QA Lead agrees? %v\n", pass)
 	if follow != "" {
 		fmt.Printf("Follow-up: %s\n", follow)
 	}
 
-	_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
+	_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
 	for _, gr := range r.GateResults {
 		fmt.Printf("Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 	}

--- a/examples/integration/main.go_old
+++ b/examples/integration/main.go_old
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
@@ -43,7 +44,7 @@ func main() {
 	}
 
 	// Store the first requirement in a project structure.
-	prj := PMFS.ProjectType{}
+	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
 
 	prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.Requirement{
 		Name:        reqs[0].Name,
@@ -55,13 +56,13 @@ func main() {
 
 	// With the client configured above, the requirement can query roles and
 	// evaluate gates directly.
-	pass, follow, _ := r.Analyse("qa_lead", "1")
+	pass, follow, _ := r.Analyse(&prj, "qa_lead", "1")
 	fmt.Printf("QA Lead agrees? %v\n", pass)
 	if follow != "" {
 		fmt.Printf("Follow-up: %s\n", follow)
 	}
 
-	_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
+	_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
 	for _, gr := range r.GateResults {
 		fmt.Printf("Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 	}

--- a/examples/project/main.go
+++ b/examples/project/main.go
@@ -94,7 +94,7 @@ func main() {
 
 	for i := range prj.D.PotentialRequirements {
 		r := &prj.D.PotentialRequirements[i]
-		pass, follow, err := r.Analyse("product_manager", "1")
+		pass, follow, err := r.Analyse(prj, "product_manager", "1")
 		if err != nil {
 			log.Fatalf("Requirement Analyse: %v", err)
 		}
@@ -102,7 +102,7 @@ func main() {
 		if follow != "" {
 			fmt.Printf("  Follow-up: %s\n", follow)
 		}
-		if err := r.EvaluateGates([]string{"clarity-form-1"}); err != nil {
+		if err := r.EvaluateGates(prj, []string{"clarity-form-1"}); err != nil {
 			log.Fatalf("EvaluateGates: %v", err)
 		}
 		for _, gr := range r.GateResults {


### PR DESCRIPTION
## Summary
- add optional LLM client field to projects
- initialize project LLM with llm.DefaultClient on create/load
- route requirement and attachment interactions through project LLM

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac1628f88c832b85beff32428da524