### PR TITLE
feat: create project with one call

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,35 @@ The default Gemini client reads `GEMINI_API_KEY` automatically. When this
 variable is set, package functions will use the live API without any
 `SetClient` call.
 
+### Start a Project in One Call
+
+With the environment prepared you can spin up a project in a single step. Set
+`PMFS_BASEDIR` (and `GEMINI_API_KEY` for live LLM features) and call
+`pmfs.NewProject`:
+
+```bash
+export PMFS_BASEDIR=/tmp/pmfs
+export GEMINI_API_KEY=your-key   # required for LLM features
+```
+
+```go
+package main
+
+import (
+    "log"
+
+    "github.com/rjboer/PMFS/pmfs"
+)
+
+func main() {
+    prj, err := pmfs.NewProject("Demo Project")
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = prj // project is ready to use
+}
+```
+
 ## Directory Structure
 
 The backend stores its data in a folder called `database`. Inside it, each product gets its own subdirectory and keeps an `index.toml` of projects.

--- a/pmfs/newproject.go
+++ b/pmfs/newproject.go
@@ -1,0 +1,46 @@
+package pmfs
+
+import (
+	"os"
+
+	PMFS "github.com/rjboer/PMFS"
+	"github.com/rjboer/PMFS/pmfs/llm"
+	"github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+// ProjectType is an alias to the core PMFS project type.
+type ProjectType = PMFS.ProjectType
+
+// NewProject ensures the data layout exists, assigns the default LLM client
+// from the environment, and creates a new project with the provided name under
+// the first product (creating a default product if necessary).
+func NewProject(name string) (*ProjectType, error) {
+	// Ensure the default client uses the API key from the environment.
+	llm.SetClient(gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY")))
+
+	// Respect runtime override of the base directory.
+	if dir := os.Getenv("PMFS_BASEDIR"); dir != "" {
+		PMFS.SetBaseDir(dir)
+	}
+
+	if err := PMFS.EnsureLayout(); err != nil {
+		return nil, err
+	}
+
+	idx, err := PMFS.LoadIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(idx.Products) == 0 {
+		if err := idx.AddProduct("Default Product"); err != nil {
+			return nil, err
+		}
+	}
+
+	prd := &idx.Products[0]
+	if err := prd.AddProject(&idx, name); err != nil {
+		return nil, err
+	}
+	return &prd.Projects[len(prd.Projects)-1], nil
+}


### PR DESCRIPTION
## Summary
- add `pmfs.NewProject` to initialize layout, default LLM client, and create a project
- document creating a project via `PMFS_BASEDIR` env var and single helper call

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac16441108832ba05380e3a380d6ec