### PR TITLE
Require GEMINI_API_KEY for examples and add mock client

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,24 +134,27 @@ A runnable sample program lives in `examples/basic` and can be run with:
  go run ./examples/basic
 ```
 
-An example demonstrating the Gemini client lives in `examples/gemini` and can be run with:
+An example demonstrating the Gemini client lives in `examples/gemini`
+(requires `GEMINI_API_KEY`) and can be run with:
 
 ```bash
 go run ./examples/gemini
 ```
 
-All Gemini-related examples replace the client with a stub so they can run
-offline. Remove those `SetClient` blocks and ensure `GEMINI_API_KEY` is set to
-call the real API. Real API flows are illustrated in `examples/gemini`,
-`examples/integration`, and `examples/full`.
+Gemini-related examples require a valid `GEMINI_API_KEY`. For a stubbed version
+that runs offline, see `examples/mock`:
 
-An example combining Gemini analysis, interactive questions, and gate evaluation lives in `examples/integration` and can be run with:
+```bash
+go run ./examples/mock
+```
+
+An example combining Gemini analysis, interactive questions, and gate evaluation lives in `examples/integration` (requires `GEMINI_API_KEY`) and can be run with:
 
 ```bash
 go run ./examples/integration
 ```
 
-An extended example that analyzes attachments, asks multiple roles, and evaluates gates lives in `examples/full` and can be run with:
+An extended example that analyzes attachments, asks multiple roles, and evaluates gates lives in `examples/full` (requires `GEMINI_API_KEY`) and can be run with:
 
 ```bash
 go run ./examples/full

--- a/examples/analyse/README.md
+++ b/examples/analyse/README.md
@@ -2,6 +2,7 @@
 
 - **Purpose:** Analyze a document attachment with a role-specific question.
 - **Key PMFS methods:** `Attachment.Analyse`, `SetBaseDir`
+- **Requires:** `GEMINI_API_KEY`
 - **Run:**
   ```bash
   go run ./examples/analyse

--- a/examples/analyse/main.go
+++ b/examples/analyse/main.go
@@ -3,28 +3,13 @@ package main
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
-	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
 // This example demonstrates analysing an attachment with a role-specific
-// question. Remove the stub below and set GEMINI_API_KEY to use the real API.
+// question. Requires the GEMINI_API_KEY environment variable.
 func main() {
-	// Stub Gemini client so the example runs without external calls.
-	// Delete this block for live API calls.
-	stub := gemini.ClientFunc{
-		AskFunc: func(prompt string) (string, error) {
-			if strings.Contains(strings.ToLower(prompt), "answer yes or no only") {
-				return "Yes", nil
-			}
-			return "stub response", nil
-		},
-	}
-	prev := gemini.SetClient(stub)
-	defer gemini.SetClient(prev)
-
 	PMFS.SetBaseDir(".")
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -2,6 +2,8 @@
 
 This example demonstrates a complete PMFS flow using the Gemini client.
 
+- **Requires:** `GEMINI_API_KEY`
+
 1. **Analyze attachment** – `gemini.AnalyzeAttachment` extracts potential requirements from `testdata/spec1.txt`.
 2. **Store requirements** – The requirements are stored in a project structure using `PMFS.FromGemini` to convert Gemini output.
 3. **Run role questions** – Each requirement's description is posed to several roles (`product_manager`, `qa_lead`, `security_privacy_officer`)

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -4,42 +4,16 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
 	llm "github.com/rjboer/PMFS/pmfs/llm"
-	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
 // This example demonstrates a full flow using Gemini to analyze a document,
 // storing the returned requirements, asking multiple role-specific questions
-// about each requirement, and evaluating them against quality gates. After the
-// Gemini client is configured, requirement methods can be used directly without
-// passing the client to interact or gates packages. Remove the stub below and
-// set GEMINI_API_KEY to call the real API with the default client.
+// about each requirement, and evaluating them against quality gates. Requires
+// the GEMINI_API_KEY environment variable.
 func main() {
-	// Stub the Gemini client so the example runs without external calls.
-	// Delete this block for live API calls.
-	stub := gemini.ClientFunc{
-		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
-			return []gemini.Requirement{
-				{ID: 1, Name: "Login", Description: "Users shall log in with email and password."},
-				{ID: 2, Name: "Logout", Description: "Users shall be able to log out securely."},
-			}, nil
-		},
-		AskFunc: func(prompt string) (string, error) {
-			p := strings.ToLower(prompt)
-			if strings.Contains(p, "answer yes or no only") {
-				return "Yes", nil
-			}
-			if strings.Contains(p, "given the requirement") {
-				return "Yes", nil
-			}
-			return "stub response", nil
-		},
-	}
-	prev := gemini.SetClient(stub)
-	defer gemini.SetClient(prev)
 	PMFS.SetBaseDir(".")
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}

--- a/examples/gates/README.md
+++ b/examples/gates/README.md
@@ -2,6 +2,7 @@
 
 - **Purpose:** Evaluate a requirement against PMFS quality gates.
 - **Key PMFS methods:** `Requirement.EvaluateGates`
+- **Requires:** `GEMINI_API_KEY`
 - **Run:**
   ```bash
   go run ./examples/gates

--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -6,22 +6,11 @@ import (
 
 	PMFS "github.com/rjboer/PMFS"
 	llm "github.com/rjboer/PMFS/pmfs/llm"
-	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
-// This example demonstrates evaluating a requirement against a gate. Remove
-// the stub below and set GEMINI_API_KEY to query the real API.
+// This example demonstrates evaluating a requirement against a gate. Requires
+// the GEMINI_API_KEY environment variable.
 func main() {
-	// Stub Gemini client so the example runs without external calls.
-	// Delete this block to use the live API.
-	stub := gemini.ClientFunc{
-		AskFunc: func(prompt string) (string, error) {
-			return "Yes", nil
-		},
-	}
-	prev := gemini.SetClient(stub)
-	defer gemini.SetClient(prev)
-
 	req := PMFS.Requirement{Description: "The system shall be user friendly."}
 	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
 	if err := req.EvaluateGates(&prj, []string{"clarity-form-1"}); err != nil {

--- a/examples/gemini/README.md
+++ b/examples/gemini/README.md
@@ -2,6 +2,7 @@
 
 - **Purpose:** Use the Gemini client to analyze a document and answer questions.
 - **Key PMFS methods:** `gemini.AnalyzeAttachment`, `gemini.Ask`
+- **Requires:** `GEMINI_API_KEY`
 - **Run:**
   ```bash
   go run ./examples/gemini

--- a/examples/gemini/main.go
+++ b/examples/gemini/main.go
@@ -7,22 +7,10 @@ import (
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
-// This example demonstrates using the Gemini client to analyze a document
-// and answer a free-form question. It swaps in a stub client so the example
-// runs without calling the real API. For production, remove the SetClient
-// block and ensure GEMINI_API_KEY is set; the default client will then invoke
-// Gemini directly.
+// This example demonstrates using the Gemini client to analyze a document and
+// answer a free-form question. Requires the GEMINI_API_KEY environment
+// variable.
 func main() {
-	prev := gemini.SetClient(gemini.ClientFunc{
-		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
-			return []gemini.Requirement{{ID: 1, Name: "Sample", Description: "From " + path}}, nil
-		},
-		AskFunc: func(prompt string) (string, error) {
-			return "stubbed answer", nil
-		},
-	})
-	defer gemini.SetClient(prev)
-
 	reqs, err := gemini.AnalyzeAttachment("testdata/spec1.txt")
 	if err != nil {
 		log.Fatalf("analyze: %v", err)

--- a/examples/integration/README.md
+++ b/examples/integration/README.md
@@ -2,6 +2,7 @@
 
 - **Purpose:** Demonstrate an end-to-end flow: analyze a document, store a requirement, query a role, and evaluate gates.
 - **Key PMFS methods:** `gemini.AnalyzeAttachment`, `Requirement.Analyse`, `Requirement.EvaluateGates`
+- **Requires:** `GEMINI_API_KEY`
 - **Run:**
   ```bash
   go run ./examples/integration

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -3,39 +3,16 @@ package main
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	PMFS "github.com/rjboer/PMFS"
 	llm "github.com/rjboer/PMFS/pmfs/llm"
-	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
 // This example demonstrates a full flow using Gemini to analyze a document,
-// storing the returned requirement, asking a role-specific question about it,
-// and finally evaluating it against quality gates. Once the Gemini client is
-// configured, requirement methods like Analyse and EvaluateGates can be called
-// directly without additional setup. Remove the stub below and set
-// GEMINI_API_KEY to exercise the real API.
+// store the returned requirement, ask a role-specific question about it, and
+// evaluate it against quality gates. Requires the GEMINI_API_KEY environment
+// variable.
 func main() {
-	// Stub the Gemini client so the example runs without external calls.
-	// Remove this block and set GEMINI_API_KEY to use the real API via
-	// the default client.
-	stub := gemini.ClientFunc{
-		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
-			return []gemini.Requirement{{ID: 1, Name: "Login", Description: "Users shall log in with email and password."}}, nil
-		},
-		AskFunc: func(prompt string) (string, error) {
-			if strings.Contains(strings.ToLower(prompt), "answer yes or no only") {
-				return "Yes", nil
-			}
-			if strings.Contains(strings.ToLower(prompt), "given the requirement") {
-				return "Yes", nil
-			}
-			return "stub response", nil
-		},
-	}
-	prev := gemini.SetClient(stub)
-	defer gemini.SetClient(prev)
 	PMFS.SetBaseDir(".")
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}

--- a/examples/mock/README.md
+++ b/examples/mock/README.md
@@ -1,0 +1,10 @@
+# Mock Example
+
+- **Purpose:** Demonstrate stubbing the Gemini client.
+- **Key PMFS methods:** `gemini.SetClient`
+- **Requires:** none (uses a stubbed client)
+- **Run:**
+  ```bash
+  go run ./examples/mock
+  ```
+

--- a/examples/mock/main.go
+++ b/examples/mock/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+// This example replaces the default Gemini client with a stub implementation.
+// It demonstrates how to mock LLM interactions for tests or offline runs.
+// No GEMINI_API_KEY is required.
+func main() {
+	prev := gemini.SetClient(gemini.ClientFunc{
+		AnalyzeAttachmentFunc: func(path string) ([]gemini.Requirement, error) {
+			return []gemini.Requirement{{ID: 1, Name: "Sample", Description: "From " + path}}, nil
+		},
+		AskFunc: func(prompt string) (string, error) {
+			return "stubbed answer", nil
+		},
+	})
+	defer gemini.SetClient(prev)
+
+	reqs, err := gemini.AnalyzeAttachment("testdata/spec1.txt")
+	if err != nil {
+		log.Fatalf("analyze: %v", err)
+	}
+	for _, r := range reqs {
+		fmt.Printf("Requirement: %s - %s\n", r.Name, r.Description)
+	}
+
+	ans, err := gemini.Ask("Summarize the spec")
+	if err != nil {
+		log.Fatalf("ask: %v", err)
+	}
+	fmt.Printf("Answer: %s\n", ans)
+}

--- a/examples/project/README.md
+++ b/examples/project/README.md
@@ -1,0 +1,10 @@
+# Project Example
+
+- **Purpose:** Demonstrate project setup, attachment ingestion, requirement analysis, and gate evaluation.
+- **Key PMFS methods:** `EnsureLayout`, `Attachment.Analyze`, `Requirement.Analyse`, `Requirement.EvaluateGates`
+- **Requires:** `GEMINI_API_KEY`
+- **Run:**
+  ```bash
+  go run ./examples/project
+  ```
+


### PR DESCRIPTION
## Summary
- remove stubbed Gemini client from functional examples
- document that examples need `GEMINI_API_KEY`
- add `examples/mock` showing how to stub the Gemini client

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac19391b7c832bab5b174209a25494