### PR TITLE
Refactor database and project APIs

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -5,34 +5,34 @@ This document lists all exported functions in the PMFS package and what they do.
 ## EnsureLayout
 Creates base folder structure and ensures `index.toml` exists.
 
-## LoadIndex
-Reads `index.toml` into the in-memory index model.
+## Load
+Reads `index.toml` into the in-memory database model.
 
-## (*Index) AddProduct
-Appends a product to the index and creates its directory skeleton.
+## (*Database) NewProduct
+Creates a product, writes the index, and returns its ID.
 
-## (*Index) SaveIndex
-Writes the in-memory index to `index.toml`.
+## (*Database) Save
+Writes the in-memory database to `index.toml`.
 
-## (*ProductType) AddProject
+## (*Product) CreateProject
 Adds a new project to a product and persists the change to disk.
 
-## (*ProjectType) SaveProject
+## (*Project) Save
 Writes the project's data to its `project.toml` file.
 
-## (*ProjectType) LoadProject
+## (*Project) Load
 Loads a project's data from its `project.toml` file.
 
-## (*ProductType) LoadProjects
+## (*Product) LoadProjects
 Loads all projects for a given product.
 
-## (*Index) LoadAllProjects
-Loads all projects for all products in the index.
+## (*Database) LoadAllProjects
+Loads all projects for all products in the database.
 
-## (*ProjectType) IngestInputDir
+## (*Project) IngestInputDir
 Scans a directory and ingests each file as an attachment.
 
-## (*ProjectType) AddAttachmentFromInput
+## (*Project) AddAttachmentFromInput
 Moves a single file into the project's attachments and records minimal metadata.
 
 ## FromGemini

--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -10,7 +10,7 @@ import (
 	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
-func TestEnsureLayoutCreatesIndex(t *testing.T) {
+func TestEnsureLayoutCreatesDatabase(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "test-key")
 	dir := t.TempDir()
 	SetBaseDir(dir)
@@ -23,63 +23,63 @@ func TestEnsureLayoutCreatesIndex(t *testing.T) {
 	}
 }
 
-func TestAddProductCreatesDirAndUpdatesIndex(t *testing.T) {
+func TestNewProductCreatesDirAndUpdatesDatabase(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "test-key")
 	dir := t.TempDir()
 	SetBaseDir(dir)
 	if err := EnsureLayout(); err != nil {
 		t.Fatalf("EnsureLayout: %v", err)
 	}
-	idx, err := LoadIndex()
+	idx, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("prod1"); err != nil {
-		t.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(ProductData{Name: "prod1"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
 	}
 	prodDir := filepath.Join(dir, productsDir, "1", "projects")
 	if _, err := os.Stat(prodDir); err != nil {
 		t.Fatalf("product dir missing: %v", err)
 	}
-	idx2, err := LoadIndex()
+	idx2, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	if len(idx2.Products) != 1 || idx2.Products[0].Name != "prod1" {
 		t.Fatalf("index not updated: %#v", idx2.Products)
 	}
 }
 
-func TestAddProjectWritesTomlAndUpdatesIndex(t *testing.T) {
+func TestCreateProjectWritesTomlAndUpdatesDatabase(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "test-key")
 	dir := t.TempDir()
 	SetBaseDir(dir)
 	if err := EnsureLayout(); err != nil {
 		t.Fatalf("EnsureLayout: %v", err)
 	}
-	idx, err := LoadIndex()
+	idx, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("prod1"); err != nil {
-		t.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(ProductData{Name: "prod1"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
 	}
 	// reload index to obtain product
-	idx, err = LoadIndex()
+	idx, err = Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	prd := &idx.Products[0]
-	if err := prd.AddProject(&idx, "prj1"); err != nil {
-		t.Fatalf("AddProject: %v", err)
+	if err := prd.CreateProject(&idx, "prj1"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
 	}
 	prjToml := filepath.Join(dir, productsDir, "1", "projects", "1", projectTOML)
 	if _, err := os.Stat(prjToml); err != nil {
 		t.Fatalf("project toml missing: %v", err)
 	}
-	idx2, err := LoadIndex()
+	idx2, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	if len(idx2.Products[0].Projects) != 1 || idx2.Products[0].Projects[0].Name != "prj1" {
 		t.Fatalf("project not persisted to index: %#v", idx2.Products[0].Projects)
@@ -99,20 +99,20 @@ func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 	if err := EnsureLayout(); err != nil {
 		t.Fatalf("EnsureLayout: %v", err)
 	}
-	idx, err := LoadIndex()
+	idx, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("prod1"); err != nil {
-		t.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(ProductData{Name: "prod1"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
 	}
-	idx, err = LoadIndex()
+	idx, err = Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	prd := &idx.Products[0]
-	if err := prd.AddProject(&idx, "prj1"); err != nil {
-		t.Fatalf("AddProject: %v", err)
+	if err := prd.CreateProject(&idx, "prj1"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
 	}
 	prj := &idx.Products[0].Projects[0]
 
@@ -145,9 +145,9 @@ func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 		t.Fatalf("attachment not analyzed")
 	}
 	// ensure metadata persisted to project.toml
-	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
-	if err := prjReload.LoadProject(); err != nil {
-		t.Fatalf("LoadProject: %v", err)
+	prjReload := Project{ID: prj.ID, ProductID: prj.ProductID}
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
 	}
 	if len(prjReload.D.Attachments) != 1 || prjReload.D.Attachments[0].Filename != fname {
 		t.Fatalf("attachment not persisted: %#v", prjReload.D.Attachments)
@@ -169,20 +169,20 @@ func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {
 	if err := EnsureLayout(); err != nil {
 		t.Fatalf("EnsureLayout: %v", err)
 	}
-	idx, err := LoadIndex()
+	idx, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("prod1"); err != nil {
-		t.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(ProductData{Name: "prod1"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
 	}
-	idx, err = LoadIndex()
+	idx, err = Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	prd := &idx.Products[0]
-	if err := prd.AddProject(&idx, "prj1"); err != nil {
-		t.Fatalf("AddProject: %v", err)
+	if err := prd.CreateProject(&idx, "prj1"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
 	}
 	prj := &idx.Products[0].Projects[0]
 
@@ -222,9 +222,9 @@ func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {
 		t.Fatalf("requirements not appended")
 	}
 	// ensure requirements persisted to disk
-	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
-	if err := prjReload.LoadProject(); err != nil {
-		t.Fatalf("LoadProject: %v", err)
+	prjReload := Project{ID: prj.ID, ProductID: prj.ProductID}
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
 	}
 	if len(prjReload.D.PotentialRequirements) != len(mockReqs) {
 		t.Fatalf("expected %d persisted requirements, got %d", len(mockReqs), len(prjReload.D.PotentialRequirements))
@@ -246,20 +246,20 @@ func TestAddAttachmentRealAPI(t *testing.T) {
 	if err := EnsureLayout(); err != nil {
 		t.Fatalf("EnsureLayout: %v", err)
 	}
-	idx, err := LoadIndex()
+	idx, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("prod1"); err != nil {
-		t.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(ProductData{Name: "prod1"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
 	}
-	idx, err = LoadIndex()
+	idx, err = Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	prd := &idx.Products[0]
-	if err := prd.AddProject(&idx, "prj1"); err != nil {
-		t.Fatalf("AddProject: %v", err)
+	if err := prd.CreateProject(&idx, "prj1"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
 	}
 	prj := &idx.Products[0].Projects[0]
 
@@ -296,9 +296,9 @@ func TestAddAttachmentRealAPI(t *testing.T) {
 		t.Fatalf("no requirements returned")
 	}
 
-	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
-	if err := prjReload.LoadProject(); err != nil {
-		t.Fatalf("LoadProject: %v", err)
+	prjReload := Project{ID: prj.ID, ProductID: prj.ProductID}
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
 	}
 	if len(prjReload.D.PotentialRequirements) == 0 {
 		t.Fatalf("requirements not persisted: %#v", prjReload.D.PotentialRequirements)
@@ -322,20 +322,20 @@ func TestIngestInputDirProcessesAllFiles(t *testing.T) {
 	if err := EnsureLayout(); err != nil {
 		t.Fatalf("EnsureLayout: %v", err)
 	}
-	idx, err := LoadIndex()
+	idx, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("prod1"); err != nil {
-		t.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(ProductData{Name: "prod1"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
 	}
-	idx, err = LoadIndex()
+	idx, err = Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	prd := &idx.Products[0]
-	if err := prd.AddProject(&idx, "prj1"); err != nil {
-		t.Fatalf("AddProject: %v", err)
+	if err := prd.CreateProject(&idx, "prj1"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
 	}
 	prj := &idx.Products[0].Projects[0]
 
@@ -368,17 +368,17 @@ func TestIngestInputDirProcessesAllFiles(t *testing.T) {
 		}
 	}
 
-	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
-	if err := prjReload.LoadProject(); err != nil {
-		t.Fatalf("LoadProject: %v", err)
+	prjReload := Project{ID: prj.ID, ProductID: prj.ProductID}
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
 	}
 	if len(prjReload.D.Attachments) != len(files) {
 		t.Fatalf("expected %d attachments persisted, got %d", len(files), len(prjReload.D.Attachments))
 	}
 
-	idxReload, err := LoadIndex()
+	idxReload, err := Load()
 	if err != nil {
-		t.Fatalf("LoadIndex: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	if err := idxReload.LoadAllProjects(); err != nil {
 		t.Fatalf("LoadAllProjects: %v", err)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ variable is set, package functions will use the live API without any
 
 With the environment prepared you can spin up a project in a single step. Set
 `PMFS_BASEDIR` (and `GEMINI_API_KEY` for live LLM features) and call
-`pmfs.NewProject`:
+`pmfs.CreateProject`:
 
 ```bash
 export PMFS_BASEDIR=/tmp/pmfs
@@ -57,7 +57,7 @@ import (
 )
 
 func main() {
-    prj, err := pmfs.NewProject("Demo Project")
+    prj, err := pmfs.CreateProject("Demo Project")
     if err != nil {
         log.Fatal(err)
     }
@@ -102,9 +102,9 @@ sequenceDiagram
 
     Dev->>PMFS: EnsureLayout()
     PMFS-->>Dev: create base folders
-    Dev->>PMFS: LoadIndex()
+    Dev->>PMFS: Load()
     PMFS-->>Dev: read index.toml
-    Dev->>PMFS: AddProduct/AddProject
+    Dev->>PMFS: NewProduct/CreateProject
     PMFS-->>Dev: write project.toml
 ```
 
@@ -123,7 +123,7 @@ func main() {
     if err := PMFS.EnsureLayout(); err != nil {
         panic(err)
     }
-    idx, _ := PMFS.LoadIndex()
+    idx, _ := PMFS.Load()
     fmt.Println(idx.Products)
 }
 ```
@@ -163,16 +163,16 @@ go run ./examples/full
 ## Available Functions
 
 - `EnsureLayout()`
-- `LoadIndex()`
-- `(*Index) AddProduct(name string) error`
-- `(*Index) SaveIndex() error`
-- `(*ProductType) AddProject(idx *Index, projectName string) error`
-- `(*ProjectType) SaveProject() error`
-- `(*ProjectType) LoadProject() error`
-- `(*ProductType) LoadProjects() error`
-- `(*Index) LoadAllProjects() error`
-- `(*ProjectType) IngestInputDir(inputDir string) ([]Attachment, error)`
-- `(*ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attachment, error)`
+- `Load()`
+- `(*Database) NewProduct(data ProductData) (int, error)`
+- `(*Database) Save() error`
+- `(*Product) CreateProject(db *Database, projectName string) error`
+- `(*Project) Save() error`
+- `(*Project) Load() error`
+- `(*Product) LoadProjects() error`
+- `(*Database) LoadAllProjects() error`
+- `(*Project) IngestInputDir(inputDir string) ([]Attachment, error)`
+- `(*Project) AddAttachmentFromInput(inputDir, filename string) (Attachment, error)`
 - `FromGemini(req gemini.Requirement) Requirement`
 
 See [FUNCTIONS.md](FUNCTIONS.md) for detailed descriptions.

--- a/database.go
+++ b/database.go
@@ -1,0 +1,240 @@
+package PMFS
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pelletier/go-toml/v2"
+	llm "github.com/rjboer/PMFS/pmfs/llm"
+)
+
+const (
+	productsDir   = "products"
+	indexFilename = "index.toml"
+	projectTOML   = "project.toml"
+	envBaseDir    = "PMFS_BASEDIR"
+)
+
+var (
+	baseDir         = defaultBaseDir()
+	baseProductsDir string
+	indexPath       string
+
+	ErrProductNotFound = errors.New("product not found")
+	ErrProjectNotFound = errors.New("project not found")
+)
+
+func init() {
+	setBaseDir(baseDir)
+}
+
+func defaultBaseDir() string {
+	if dir := os.Getenv(envBaseDir); dir != "" {
+		return dir
+	}
+	return "database"
+}
+
+// SetBaseDir overrides the base data directory and updates internal paths.
+func SetBaseDir(dir string) {
+	baseDir = dir
+	setBaseDir(dir)
+}
+
+func setBaseDir(dir string) {
+	baseProductsDir = filepath.Join(dir, productsDir)
+	indexPath = filepath.Join(baseProductsDir, indexFilename)
+}
+
+// -----------------------------------------------------------------------------
+// Memory model
+// -----------------------------------------------------------------------------
+
+// Database holds a list of products.
+type Database struct {
+	Products []Product `toml:"products"`
+}
+
+// Product represents a product with a set of projects.
+type Product struct {
+	ProductData
+	Projects []Project `toml:"projects"`
+}
+
+// ProductData is the metadata stored for a product.
+type ProductData struct {
+	ID   int    `json:"id" toml:"id"`
+	Name string `json:"name" toml:"name"`
+}
+
+// -----------------------------------------------------------------------------
+// Filesystem helpers
+// -----------------------------------------------------------------------------
+
+// EnsureLayout creates base folder structure and ensures index.toml exists.
+func EnsureLayout() error {
+	if err := os.MkdirAll(baseProductsDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", baseProductsDir, err)
+	}
+	if ok, err := fileExists(indexPath); err != nil {
+		return err
+	} else if !ok {
+		idx := Database{Products: []Product{}}
+		if err := writeTOML(indexPath, &idx); err != nil {
+			return fmt.Errorf("write index.toml: %w", err)
+		}
+	}
+	return nil
+}
+
+// Load reads index.toml into the shallow model.
+func Load() (Database, error) {
+	var idx Database
+	if err := readTOML(indexPath, &idx); err != nil {
+		if os.IsNotExist(err) {
+			idx = Database{Products: []Product{}}
+			if werr := writeTOML(indexPath, &idx); werr != nil {
+				return idx, werr
+			}
+			return idx, nil
+		}
+		return idx, fmt.Errorf("read index.toml: %w", err)
+	}
+	if idx.Products == nil {
+		idx.Products = []Product{}
+	}
+	return idx, nil
+}
+
+// Save writes the database index to disk.
+func (db *Database) Save() error {
+	if err := writeTOML(indexPath, db); err != nil {
+		return fmt.Errorf("write index: %w", err)
+	}
+	return nil
+}
+
+// NewProduct creates a product, writes index.toml, and returns its ID.
+// ProductID = len(db.Products) + 1
+func (db *Database) NewProduct(data ProductData) (int, error) {
+	if data.Name == "" {
+		return 0, errors.New("product name cannot be empty")
+	}
+
+	newID := len(db.Products) + 1
+	pDir := productDir(newID)
+
+	if err := os.MkdirAll(filepath.Join(pDir, "projects"), 0o755); err != nil {
+		return 0, fmt.Errorf("mkdir product/projects: %w", err)
+	}
+
+	db.Products = append(db.Products, Product{
+		ProductData: ProductData{ID: newID, Name: data.Name},
+		Projects:    []Project{},
+	})
+	if err := db.Save(); err != nil {
+		return 0, fmt.Errorf("error saving index, NewProduct: %w", err)
+	}
+	return newID, nil
+}
+
+// ModifyProduct updates existing product metadata and persists the index.
+func (db *Database) ModifyProduct(data ProductData) (int, error) {
+	for i := range db.Products {
+		if db.Products[i].ID == data.ID {
+			if data.Name != "" {
+				db.Products[i].Name = data.Name
+			}
+			if err := db.Save(); err != nil {
+				return 0, fmt.Errorf("error saving index, ModifyProduct: %w", err)
+			}
+			return data.ID, nil
+		}
+	}
+	return 0, ErrProductNotFound
+}
+
+// CreateProject appends a project to the given product and writes its TOML.
+// projectID = len(product.Projects) + 1
+// db must be the database containing this product so the index can be persisted.
+func (prd *Product) CreateProject(db *Database, projectName string) error {
+	if projectName == "" {
+		return errors.New("project name cannot be empty")
+	}
+	if db == nil {
+		return errors.New("database cannot be nil")
+	}
+
+	newPrjID := len(prd.Projects) + 1
+	prjDir := projectDir(prd.ID, newPrjID)
+	if err := os.MkdirAll(prjDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir project dir: %w", err)
+	}
+
+	added := Project{ID: newPrjID, ProductID: prd.ID, Name: projectName, LLM: llm.DefaultClient}
+	if err := added.Save(); err != nil {
+		return fmt.Errorf("error saving TOML, CreateProject: %w", err)
+	}
+
+	prd.Projects = append(prd.Projects, added)
+	if err := db.Save(); err != nil {
+		return fmt.Errorf("error saving index, CreateProject: %w", err)
+	}
+	return nil
+}
+
+// LoadAllProjects loads all projects for all products in the database.
+func (db *Database) LoadAllProjects() error {
+	for i := range db.Products {
+		if err := db.Products[i].LoadProjects(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Small helpers
+// -----------------------------------------------------------------------------
+
+func productDir(productID int) string {
+	return filepath.Join(baseProductsDir, strconv.Itoa(productID))
+}
+
+func projectDir(productID, projectID int) string {
+	return filepath.Join(productDir(productID), "projects", strconv.Itoa(projectID))
+}
+
+func attachmentDir(productID, projectID int) string {
+	return filepath.Join(productDir(productID), "projects", strconv.Itoa(projectID), "attachments")
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func writeTOML(path string, v any) error {
+	data, err := toml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("toml marshal: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func readTOML(path string, v any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return toml.Unmarshal(b, v)
+}

--- a/examples/analyse/main.go
+++ b/examples/analyse/main.go
@@ -11,7 +11,7 @@ import (
 // question. Requires the GEMINI_API_KEY environment variable.
 func main() {
 	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
+	prj := PMFS.Project{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	pass, follow, err := att.Analyse("product_manager", "1", &prj)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,7 +1,7 @@
 # Basic Example
 
 - **Purpose:** Initialize a PMFS directory structure, add a product and project, and list them.
-- **Key PMFS methods:** `EnsureLayout`, `LoadIndex`, `(*Index).AddProduct`, `(*ProductType).AddProject`
+- **Key PMFS methods:** `EnsureLayout`, `Load`, `(*Database).NewProduct`, `(*Product).CreateProject`
 - **Run:**
   ```bash
   go run ./examples/basic

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -15,16 +15,16 @@ func main() {
 		log.Fatalf("ensure layout: %v", err)
 	}
 
-	idx, err := PMFS.LoadIndex()
+	idx, err := PMFS.Load()
 	if err != nil {
-		log.Fatalf("load index: %v", err)
+		log.Fatalf("load database: %v", err)
 	}
 
 	if len(idx.Products) == 0 {
-		if err := idx.AddProduct("Example Product"); err != nil {
+		if _, err := idx.NewProduct(PMFS.ProductData{Name: "Example Product"}); err != nil {
 			log.Fatalf("add product: %v", err)
 		}
-		if err := idx.Products[0].AddProject(&idx, "Example Project"); err != nil {
+		if err := idx.Products[0].CreateProject(&idx, "Example Project"); err != nil {
 			log.Fatalf("add project: %v", err)
 		}
 	}

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -15,7 +15,7 @@ import (
 // the GEMINI_API_KEY environment variable.
 func main() {
 	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
+	prj := PMFS.Project{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.

--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -12,7 +12,7 @@ import (
 // the GEMINI_API_KEY environment variable.
 func main() {
 	req := PMFS.Requirement{Description: "The system shall be user friendly."}
-	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
+	prj := PMFS.Project{LLM: llm.DefaultClient}
 	if err := req.EvaluateGates(&prj, []string{"clarity-form-1"}); err != nil {
 		log.Fatalf("EvaluateGates: %v", err)
 	}

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -14,7 +14,7 @@ import (
 // variable.
 func main() {
 	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
+	prj := PMFS.Project{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.

--- a/examples/project/main.go
+++ b/examples/project/main.go
@@ -34,15 +34,15 @@ func main() {
 		log.Fatalf("EnsureLayout: %v", err)
 	}
 
-	idx, err := PMFS.LoadIndex()
+	idx, err := PMFS.Load()
 	if err != nil {
-		log.Fatalf("LoadIndex: %v", err)
+		log.Fatalf("Load: %v", err)
 	}
-	if err := idx.AddProduct("Demo Product"); err != nil {
-		log.Fatalf("AddProduct: %v", err)
+	if _, err := idx.NewProduct(PMFS.ProductData{Name: "Demo Product"}); err != nil {
+		log.Fatalf("NewProduct: %v", err)
 	}
-	if err := idx.Products[0].AddProject(&idx, "Demo Project"); err != nil {
-		log.Fatalf("AddProject: %v", err)
+	if err := idx.Products[0].CreateProject(&idx, "Demo Project"); err != nil {
+		log.Fatalf("CreateProject: %v", err)
 	}
 	prj := &idx.Products[0].Projects[0]
 	prj.LLM = llm.DefaultClient

--- a/pmfs/createproject.go
+++ b/pmfs/createproject.go
@@ -8,13 +8,13 @@ import (
 	"github.com/rjboer/PMFS/pmfs/llm/gemini"
 )
 
-// ProjectType is an alias to the core PMFS project type.
-type ProjectType = PMFS.ProjectType
+// Project is an alias to the core PMFS project type.
+type Project = PMFS.Project
 
-// NewProject ensures the data layout exists, assigns the default LLM client
+// CreateProject ensures the data layout exists, assigns the default LLM client
 // from the environment, and creates a new project with the provided name under
 // the first product (creating a default product if necessary).
-func NewProject(name string) (*ProjectType, error) {
+func CreateProject(name string) (*Project, error) {
 	// Ensure the default client uses the API key from the environment.
 	llm.SetClient(gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY")))
 
@@ -27,19 +27,19 @@ func NewProject(name string) (*ProjectType, error) {
 		return nil, err
 	}
 
-	idx, err := PMFS.LoadIndex()
+	idx, err := PMFS.Load()
 	if err != nil {
 		return nil, err
 	}
 
 	if len(idx.Products) == 0 {
-		if err := idx.AddProduct("Default Product"); err != nil {
+		if _, err := idx.NewProduct(PMFS.ProductData{Name: "Default Product"}); err != nil {
 			return nil, err
 		}
 	}
 
 	prd := &idx.Products[0]
-	if err := prd.AddProject(&idx, name); err != nil {
+	if err := prd.CreateProject(&idx, name); err != nil {
 		return nil, err
 	}
 	return &prd.Projects[len(prd.Projects)-1], nil


### PR DESCRIPTION
## Summary
- split database logic into dedicated `database.go` and move remaining project code to `project.go`
- add `Database.Load`, `Database.NewProduct`, `Database.ModifyProduct`, and `Product.CreateProject` for clearer product management
- rename project helper to `pmfs.CreateProject` and update tests, docs, and examples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68acd2f75424832bbaaf3e3198d3070f