### PR TITLE
Add project creation and lookup helpers

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -15,7 +15,10 @@ Updates an existing product and persists the change to `index.toml`.
 Writes the in-memory database to `index.toml`.
 
 ## (*ProductType) NewProject
-Adds a new project to a product and persists the change to disk.
+Adds a new project to a product, writes its `project.toml` and updates the index.
+
+## (*ProductType) Project
+Loads and returns a specific project by ID.
 
 ## (*ProjectType) Save
 Writes the project's data to its `project.toml` file.

--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -89,7 +89,7 @@ func TestNewProjectWritesTomlAndUpdatesIndex(t *testing.T) {
 		t.Fatalf("LoadSetup: %v", err)
 	}
 	prd := &db.Products[0]
-	if _, err := prd.NewProject("prj1"); err != nil {
+	if _, err := prd.NewProject(db, ProjectData{Name: "prj1"}); err != nil {
 		t.Fatalf("NewProject: %v", err)
 	}
 	if err := db.Save(); err != nil {
@@ -136,7 +136,7 @@ func TestAddAttachmentFromInputMovesFileAndRecordsMetadata(t *testing.T) {
 	}
 	prd := &db.Products[0]
 
-	if _, err := prd.NewProject("prj1"); err != nil {
+	if _, err := prd.NewProject(db, ProjectData{Name: "prj1"}); err != nil {
 		t.Fatalf("NewProject: %v", err)
 
 	}
@@ -209,7 +209,7 @@ func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {
 	}
 	prd := &db.Products[0]
 
-	if _, err := prd.NewProject("prj1"); err != nil {
+	if _, err := prd.NewProject(db, ProjectData{Name: "prj1"}); err != nil {
 		t.Fatalf("NewProject: %v", err)
 
 	}
@@ -287,7 +287,7 @@ func TestAddAttachmentRealAPI(t *testing.T) {
 		t.Fatalf("LoadSetup: %v", err)
 	}
 	prd := &db.Products[0]
-	if _, err := prd.NewProject("prj1"); err != nil {
+	if _, err := prd.NewProject(db, ProjectData{Name: "prj1"}); err != nil {
 		t.Fatalf("NewProject: %v", err)
 	}
 	if err := db.Save(); err != nil {
@@ -364,7 +364,7 @@ func TestIngestInputDirProcessesAllFiles(t *testing.T) {
 		t.Fatalf("LoadSetup: %v", err)
 	}
 	prd := &db.Products[0]
-	if _, err := prd.NewProject("prj1"); err != nil {
+	if _, err := prd.NewProject(db, ProjectData{Name: "prj1"}); err != nil {
 		t.Fatalf("NewProject: %v", err)
 	}
 	if err := db.Save(); err != nil {

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ go run ./examples/full
 - `(*Database) NewProduct(data ProductData) (int, error)`
 - `(*Database) ModifyProduct(data ProductData) (int, error)`
 - `(*Database) Save() error`
-- `(*ProductType) NewProject(name string) (*ProjectType, error)`
+- `(*ProductType) NewProject(db *Database, data ProjectData) (int, error)`
+- `(*ProductType) Project(id int) (*ProjectType, error)`
 - `(*ProjectType) Save() error`
 - `(*ProjectType) Load() error`
 

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -23,8 +23,7 @@ func main() {
 			log.Fatalf("add product: %v", err)
 		}
 		p := &db.Products[id-1]
-		if _, err := p.NewProject("Example Project"); err != nil {
-
+		if _, err := p.NewProject(db, PMFS.ProjectData{Name: "Example Project"}); err != nil {
 			log.Fatalf("add project: %v", err)
 		}
 		if err := db.Save(); err != nil {

--- a/examples/project/main.go
+++ b/examples/project/main.go
@@ -39,10 +39,13 @@ func main() {
 		log.Fatalf("NewProduct: %v", err)
 	}
 	p := &db.Products[id-1]
-	prj, err := p.NewProject("Demo Project")
+	prjID, err := p.NewProject(db, PMFS.ProjectData{Name: "Demo Project"})
 	if err != nil {
 		log.Fatalf("NewProject: %v", err)
-
+	}
+	prj, err := p.Project(prjID)
+	if err != nil {
+		log.Fatalf("Project: %v", err)
 	}
 	prj.LLM = llm.DefaultClient
 	if err := db.Save(); err != nil {

--- a/pmfs/newproject.go
+++ b/pmfs/newproject.go
@@ -38,12 +38,13 @@ func NewProject(name string) (*ProjectType, error) {
 
 	prd := &db.Products[0]
 
-	prj, err := prd.NewProject(name)
-
+	id, err := prd.NewProject(db, PMFS.ProjectData{Name: name})
 	if err != nil {
 		return nil, err
 	}
-	if err := db.Save(); err != nil {
+
+	prj, err := prd.Project(id)
+	if err != nil {
 		return nil, err
 	}
 	return prj, nil


### PR DESCRIPTION
## Summary
- allow creating a project with structured data via `ProductType.NewProject`
- support retrieving a specific project with `ProductType.Project`
- update examples, docs and tests for new APIs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ade72b31fc832b91b6c7fde166f1ef