### PR TITLE
Use project LLM client automatically

### DIFF
--- a/requirement_suggest_test.go
+++ b/requirement_suggest_test.go
@@ -18,7 +18,8 @@ func TestRequirementSuggestOthers(t *testing.T) {
 		}
 		return mockResp, nil
 	}}
-	reqs, err := r.SuggestOthers(client)
+	prj := &ProjectType{LLM: client}
+	reqs, err := r.SuggestOthers(prj)
 	if err != nil {
 		t.Fatalf("SuggestOthers: %v", err)
 	}
@@ -32,7 +33,8 @@ func TestRequirementSuggestOthersMalformed(t *testing.T) {
 	client := gemini.ClientFunc{AskFunc: func(prompt string) (string, error) {
 		return "not json", nil
 	}}
-	if _, err := r.SuggestOthers(client); err == nil {
+	prj := &ProjectType{LLM: client}
+	if _, err := r.SuggestOthers(prj); err == nil {
 		t.Fatalf("expected error for malformed response")
 	}
 }


### PR DESCRIPTION
## Summary
- initialize project LLM from `GEMINI_API_KEY` in `LoadSetup`
- use project-specific LLM for attachment analysis and requirement suggestions
- adjust tests for project LLM usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af6c1f2468832b8323b3945134bef0