### PR TITLE
Add project modify helper and default LLM

### DIFF
--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -17,6 +17,9 @@ Writes the in-memory database to `index.toml`.
 ## (*ProductType) NewProject
 Adds a new project to a product, writes its `project.toml` and updates the index.
 
+## (*ProductType) ModifyProject
+Updates an existing project and persists its `project.toml` and the index.
+
 ## (*ProductType) Project
 Loads and returns a specific project by ID.
 
@@ -33,10 +36,10 @@ Loads all projects for a given product.
 Loads all projects for all products in the database.
 
 ## (*ProjectType) IngestInputDir
-Scans a directory and ingests each file as an attachment.
+Scans a directory and ingests each file as an attachment using the database's LLM.
 
 ## (*ProjectType) AddAttachmentFromInput
-Moves a single file into the project's attachments and records minimal metadata.
+Moves a single file into the project's attachments, analyzes it with the database's LLM, and records minimal metadata.
 
 
 ## (*Requirement) QualityControlAI

--- a/PMFS.go
+++ b/PMFS.go
@@ -70,6 +70,7 @@ func setBaseDir(dir string) {
 type Database struct {
 	BaseDir  string        `toml:"-"`
 	Products []ProductType `toml:"products"`
+	LLM      llm.Client    `toml:"-" json:"-"`
 }
 
 // LoadSetup initialises the database at the provided path. It sets the
@@ -91,14 +92,7 @@ func LoadSetup(path string) (*Database, error) {
 		return nil, err
 	}
 	db.BaseDir = path
-
-	// Ensure every project uses the default LLM client configured via
-	// the GEMINI_API_KEY environment variable.
-	for i := range db.Products {
-		for j := range db.Products[i].Projects {
-			db.Products[i].Projects[j].LLM = llm.DefaultClient
-		}
-	}
+	db.LLM = llm.DefaultClient
 
 	return db, nil
 }
@@ -128,8 +122,7 @@ type ProjectType struct {
 	// D contains the heavy project data and is stored only in each
 	// project's individual TOML file. The field is skipped when the
 	// index is written to disk so the index remains lightweight.
-	D   ProjectData `json:"projectdata" toml:"-"`
-	LLM llm.Client  `json:"-" toml:"-"`
+	D ProjectData `json:"projectdata" toml:"-"`
 }
 
 type ProjectData struct {
@@ -183,15 +176,15 @@ func FromGemini(req gemini.Requirement) Requirement {
 }
 
 // Analyse sends the requirement description to the provided role/question pair
-// using the project's configured LLM and returns the result.
-func (r *Requirement) Analyse(prj *ProjectType, role, questionID string) (bool, string, error) {
-	return interact.RunQuestion(prj.LLM, role, questionID, r.Description)
+// using the database's configured LLM and returns the result.
+func (r *Requirement) Analyse(db *Database, role, questionID string) (bool, string, error) {
+	return interact.RunQuestion(db.LLM, role, questionID, r.Description)
 }
 
 // EvaluateGates runs the specified gates against the requirement description
-// using the project's configured LLM and stores the results on the requirement.
-func (r *Requirement) EvaluateGates(prj *ProjectType, gateIDs []string) error {
-	res, err := gates.Evaluate(prj.LLM, gateIDs, r.Description)
+// using the database's configured LLM and stores the results on the requirement.
+func (r *Requirement) EvaluateGates(db *Database, gateIDs []string) error {
+	res, err := gates.Evaluate(db.LLM, gateIDs, r.Description)
 	if err != nil {
 		return err
 	}
@@ -199,15 +192,14 @@ func (r *Requirement) EvaluateGates(prj *ProjectType, gateIDs []string) error {
 	return nil
 }
 
-
 // QualityControlAI runs Analyse and EvaluateGates on the requirement.
 // It returns the result of Analyse and stores gate evaluation results on the requirement.
-func (r *Requirement) QualityControlAI(prj *ProjectType, role, questionID string, gateIDs []string) (bool, string, error) {
-	pass, ans, err := r.Analyse(prj, role, questionID)
+func (r *Requirement) QualityControlAI(db *Database, role, questionID string, gateIDs []string) (bool, string, error) {
+	pass, ans, err := r.Analyse(db, role, questionID)
 	if err != nil {
 		return pass, ans, err
 	}
-	if err := r.EvaluateGates(prj, gateIDs); err != nil {
+	if err := r.EvaluateGates(db, gateIDs); err != nil {
 		return pass, ans, err
 	}
 	return pass, ans, nil
@@ -216,9 +208,9 @@ func (r *Requirement) QualityControlAI(prj *ProjectType, role, questionID string
 // SuggestOthers asks the client for related potential requirements based on
 
 // this requirement's description and returns them.
-func (r *Requirement) SuggestOthers(prj *ProjectType) ([]Requirement, error) {
+func (r *Requirement) SuggestOthers(db *Database) ([]Requirement, error) {
 	prompt := fmt.Sprintf("Given the requirement %q, list other potential requirements (JSON array with `name` and `description`).", r.Description)
-	resp, err := prj.LLM.Ask(prompt)
+	resp, err := db.LLM.Ask(prompt)
 	if err != nil {
 		return nil, err
 	}
@@ -242,23 +234,22 @@ type Attachment struct {
 // Analyze processes the attachment using the default strategy and appends
 // proposed requirements. It is kept for backward compatibility and delegates to
 // GenerateRequirements with an empty strategy.
-func (att *Attachment) Analyze(prj *ProjectType) error {
-	return att.GenerateRequirements(prj, "")
+func (att *Attachment) Analyze(db *Database, prj *ProjectType) error {
+	return att.GenerateRequirements(db, prj, "")
 }
 
 // GenerateRequirements analyzes the attachment using the provided heuristic
 // strategy and appends any discovered requirements to the project's potential
 // requirements slice. An empty strategy falls back to the default LLM-based
 // analysis (currently Gemini).
-func (att *Attachment) GenerateRequirements(prj *ProjectType, strategy string) error {
+func (att *Attachment) GenerateRequirements(db *Database, prj *ProjectType, strategy string) error {
 	if strategy == "" {
 		strategy = "gemini"
 	}
 
 	full := filepath.Join(projectDir(prj.ProductID, prj.ID), att.RelPath)
 
-	reqs, err := prj.LLM.AnalyzeAttachment(full)
-
+	reqs, err := db.LLM.AnalyzeAttachment(full)
 	if err != nil {
 		return err
 	}
@@ -272,7 +263,7 @@ func (att *Attachment) GenerateRequirements(prj *ProjectType, strategy string) e
 // Analyse loads the attachment content and asks a role-specific question about it.
 // For text files the content is read directly; for other files existing upload
 // logic is used to extract textual content before querying the LLM.
-func (att *Attachment) Analyse(role, questionID string, prj *ProjectType) (bool, string, error) {
+func (att *Attachment) Analyse(db *Database, role, questionID string, prj *ProjectType) (bool, string, error) {
 	full := filepath.Join(projectDir(prj.ProductID, prj.ID), att.RelPath)
 	mt := mime.TypeByExtension(strings.ToLower(filepath.Ext(full)))
 	if i := strings.Index(mt, ";"); i >= 0 {
@@ -286,7 +277,7 @@ func (att *Attachment) Analyse(role, questionID string, prj *ProjectType) (bool,
 		}
 		content = string(b)
 	} else {
-		reqs, err := prj.LLM.AnalyzeAttachment(full)
+		reqs, err := db.LLM.AnalyzeAttachment(full)
 		if err != nil {
 			return false, "", err
 		}
@@ -299,7 +290,7 @@ func (att *Attachment) Analyse(role, questionID string, prj *ProjectType) (bool,
 		}
 		content = sb.String()
 	}
-	return interact.RunQuestion(prj.LLM, role, questionID, content)
+	return interact.RunQuestion(db.LLM, role, questionID, content)
 }
 
 // ChangeLog records a change made to a requirement.
@@ -428,7 +419,6 @@ func (prd *ProductType) NewProject(db *Database, data ProjectData) (int, error) 
 		ProductID: prd.ID,
 		Name:      data.Name,
 		D:         data,
-		LLM:       llm.DefaultClient,
 	}
 
 	if err := prj.Save(); err != nil {
@@ -440,6 +430,29 @@ func (prd *ProductType) NewProject(db *Database, data ProjectData) (int, error) 
 		return 0, err
 	}
 	return newPrjID, nil
+}
+
+// ModifyProject updates a project's fields and persists both the project and index.
+func (prd *ProductType) ModifyProject(db *Database, id int, data ProjectData) (int, error) {
+	for i := range prd.Projects {
+		if prd.Projects[i].ID == id {
+			if data.Name != "" {
+				prd.Projects[i].Name = data.Name
+				prd.Projects[i].D.Name = data.Name
+			} else {
+				data.Name = prd.Projects[i].D.Name
+			}
+			prd.Projects[i].D = data
+			if err := prd.Projects[i].Save(); err != nil {
+				return 0, err
+			}
+			if err := db.Save(); err != nil {
+				return 0, err
+			}
+			return id, nil
+		}
+	}
+	return 0, ErrProjectNotFound
 }
 
 // Save writes the project's data to its project.toml.
@@ -496,7 +509,6 @@ func (prj *ProjectType) Load() error {
 	prj.ProductID = dp.ProductID
 	prj.Name = dp.Name
 	prj.D = dp.D
-	prj.LLM = llm.DefaultClient
 	return nil
 }
 
@@ -657,7 +669,7 @@ func detectMimeType(path string) string {
 }
 
 // IngestInputDir scans inputDir and ingests all regular files into attachments/.
-func (prj *ProjectType) IngestInputDir(inputDir string) ([]Attachment, error) {
+func (prj *ProjectType) IngestInputDir(db *Database, inputDir string) ([]Attachment, error) {
 	entries, err := os.ReadDir(inputDir)
 	if err != nil {
 		return nil, err
@@ -679,7 +691,7 @@ func (prj *ProjectType) IngestInputDir(inputDir string) ([]Attachment, error) {
 
 	ingested := make([]Attachment, 0, len(names))
 	for _, n := range names {
-		att, err := prj.AddAttachmentFromInput(inputDir, n)
+		att, err := prj.AddAttachmentFromInput(db, inputDir, n)
 		if err != nil {
 			return ingested, err // fail fast; or change to continue if you prefer
 		}
@@ -690,7 +702,7 @@ func (prj *ProjectType) IngestInputDir(inputDir string) ([]Attachment, error) {
 
 // AddAttachmentFromInput moves a single file from inputDir into this project's
 // attachments/<id>/ folder, records minimal metadata, and saves the project.
-func (prj *ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attachment, error) {
+func (prj *ProjectType) AddAttachmentFromInput(db *Database, inputDir, filename string) (Attachment, error) {
 	inputPath := filepath.Join(inputDir, filename)
 	if ok, err := fileExists(inputPath); err != nil {
 		return Attachment{}, err
@@ -742,7 +754,7 @@ func (prj *ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attac
 	}
 	prj.D.Attachments = append(prj.D.Attachments, att)
 	ptr := &prj.D.Attachments[len(prj.D.Attachments)-1]
-	if err := ptr.Analyze(prj); err != nil {
+	if err := ptr.Analyze(db, prj); err != nil {
 		return *ptr, err
 	}
 
@@ -754,9 +766,9 @@ func (prj *ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attac
 }
 
 // QualityControlScanALL runs QualityControlAI on every requirement in the project.
-func (prj *ProjectType) QualityControlScanALL(role, questionID string, gateIDs []string) error {
+func (prj *ProjectType) QualityControlScanALL(db *Database, role, questionID string, gateIDs []string) error {
 	for i := range prj.D.Requirements {
-		if _, _, err := prj.D.Requirements[i].QualityControlAI(prj, role, questionID, gateIDs); err != nil {
+		if _, _, err := prj.D.Requirements[i].QualityControlAI(db, role, questionID, gateIDs); err != nil {
 			return err
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -168,15 +168,16 @@ go run ./examples/full
 - `(*Database) ModifyProduct(data ProductData) (int, error)`
 - `(*Database) Save() error`
 - `(*ProductType) NewProject(db *Database, data ProjectData) (int, error)`
+- `(*ProductType) ModifyProject(db *Database, id int, data ProjectData) (int, error)`
 - `(*ProductType) Project(id int) (*ProjectType, error)`
 - `(*ProjectType) Save() error`
 - `(*ProjectType) Load() error`
 
 - `(*ProductType) LoadProjects() error`
 - `(*Database) LoadAllProjects() error`
-- `(*ProjectType) IngestInputDir(inputDir string) ([]Attachment, error)`
-- `(*ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attachment, error)`
-- `(*ProjectType) Attachments() AttachmentManager`
+- `(*ProjectType) IngestInputDir(db *Database, inputDir string) ([]Attachment, error)`
+- `(*ProjectType) AddAttachmentFromInput(db *Database, inputDir, filename string) (Attachment, error)`
+- `(*ProjectType) Attachments(db *Database) AttachmentManager`
 - `(*AttachmentManager) AddFromInputFolder() ([]Attachment, error)`
 - `FromGemini(req gemini.Requirement) Requirement`
 

--- a/attachments_manager.go
+++ b/attachments_manager.go
@@ -9,11 +9,12 @@ import (
 // AttachmentManager provides helper methods for managing attachments of a project.
 type AttachmentManager struct {
 	prj *ProjectType
+	db  *Database
 }
 
 // Attachments returns an AttachmentManager for this project.
-func (prj *ProjectType) Attachments() AttachmentManager {
-	return AttachmentManager{prj: prj}
+func (prj *ProjectType) Attachments(db *Database) AttachmentManager {
+	return AttachmentManager{prj: prj, db: db}
 }
 
 // AddFromInputFolder scans the project's default "input" directory and ingests
@@ -45,7 +46,7 @@ func (am AttachmentManager) AddFromInputFolder() ([]Attachment, error) {
 
 	ingested := make([]Attachment, 0, len(names))
 	for _, n := range names {
-		att, err := am.prj.AddAttachmentFromInput(inputDir, n)
+		att, err := am.prj.AddAttachmentFromInput(am.db, inputDir, n)
 		if err != nil {
 			return ingested, err
 		}

--- a/examples/analyse/README.md
+++ b/examples/analyse/README.md
@@ -1,7 +1,7 @@
 # Analyse Example
 
 - **Purpose:** Analyze a document attachment with a role-specific question.
-- **Key PMFS methods:** `Attachment.Analyse`, `SetBaseDir`
+- **Key PMFS methods:** `LoadSetup`, `Attachment.Analyse`
 - **Requires:** `GEMINI_API_KEY`
 - **Run:**
   ```bash

--- a/examples/analyse/main.go
+++ b/examples/analyse/main.go
@@ -10,11 +10,14 @@ import (
 // This example demonstrates analysing an attachment with a role-specific
 // question. Requires the GEMINI_API_KEY environment variable.
 func main() {
-	PMFS.SetBaseDir(".")
+	db, err := PMFS.LoadSetup(".")
+	if err != nil {
+		log.Fatalf("LoadSetup: %v", err)
+	}
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
-	pass, follow, err := att.Analyse("product_manager", "1", &prj)
+	pass, follow, err := att.Analyse(db, "product_manager", "1", &prj)
 	if err != nil {
 		log.Fatalf("Analyse: %v", err)
 	}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -26,9 +26,6 @@ func main() {
 		if _, err := p.NewProject(db, PMFS.ProjectData{Name: "Example Project"}); err != nil {
 			log.Fatalf("add project: %v", err)
 		}
-		if err := db.Save(); err != nil {
-			log.Fatalf("save index: %v", err)
-		}
 	}
 
 	for _, p := range db.Products {

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	PMFS "github.com/rjboer/PMFS"
-	llm "github.com/rjboer/PMFS/pmfs/llm"
 )
 
 // This example demonstrates a full flow using Gemini to analyze a document,
@@ -14,12 +13,15 @@ import (
 // about each requirement, and evaluating them against quality gates. Requires
 // the GEMINI_API_KEY environment variable.
 func main() {
-	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
+	db, err := PMFS.LoadSetup(".")
+	if err != nil {
+		log.Fatalf("LoadSetup: %v", err)
+	}
+	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.
-	if err := att.Analyze(&prj); err != nil {
+	if err := att.Analyze(db, &prj); err != nil {
 		log.Fatalf("analyze: %v", err)
 	}
 	if len(prj.D.PotentialRequirements) == 0 {
@@ -34,14 +36,14 @@ func main() {
 		fmt.Printf("Requirement %d: %s - %s\n", i+1, r.Name, r.Description)
 		id := strconv.Itoa(i + 1)
 		for _, role := range roles {
-			pass, follow, _ := r.Analyse(&prj, role, id)
+			pass, follow, _ := r.Analyse(db, role, id)
 			fmt.Printf("  %s agrees? %v\n", role, pass)
 			if follow != "" {
 				fmt.Printf("    Follow-up: %s\n", follow)
 			}
 		}
 
-		_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
+		_ = r.EvaluateGates(db, []string{"clarity-form-1", "duplicate-1"})
 		for _, gr := range r.GateResults {
 			fmt.Printf("  Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 		}

--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -5,15 +5,17 @@ import (
 	"log"
 
 	PMFS "github.com/rjboer/PMFS"
-	llm "github.com/rjboer/PMFS/pmfs/llm"
 )
 
 // This example demonstrates evaluating a requirement against a gate. Requires
 // the GEMINI_API_KEY environment variable.
 func main() {
+	db, err := PMFS.LoadSetup(".")
+	if err != nil {
+		log.Fatalf("LoadSetup: %v", err)
+	}
 	req := PMFS.Requirement{Description: "The system shall be user friendly."}
-	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
-	if err := req.EvaluateGates(&prj, []string{"clarity-form-1"}); err != nil {
+	if err := req.EvaluateGates(db, []string{"clarity-form-1"}); err != nil {
 		log.Fatalf("EvaluateGates: %v", err)
 	}
 	for _, gr := range req.GateResults {

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	PMFS "github.com/rjboer/PMFS"
-	llm "github.com/rjboer/PMFS/pmfs/llm"
 )
 
 // This example demonstrates a full flow using Gemini to analyze a document,
@@ -13,12 +12,15 @@ import (
 // evaluate it against quality gates. Requires the GEMINI_API_KEY environment
 // variable.
 func main() {
-	PMFS.SetBaseDir(".")
-	prj := PMFS.ProjectType{ProductID: 0, ID: 0, LLM: llm.DefaultClient}
+	db, err := PMFS.LoadSetup(".")
+	if err != nil {
+		log.Fatalf("LoadSetup: %v", err)
+	}
+	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.
-	if err := att.Analyze(&prj); err != nil {
+	if err := att.Analyze(db, &prj); err != nil {
 		log.Fatalf("analyze: %v", err)
 	}
 	if len(prj.D.PotentialRequirements) == 0 {
@@ -31,13 +33,13 @@ func main() {
 
 	// With the client configured above, the requirement can query roles and
 	// evaluate gates directly.
-	pass, follow, _ := r.Analyse(&prj, "qa_lead", "1")
+	pass, follow, _ := r.Analyse(db, "qa_lead", "1")
 	fmt.Printf("QA Lead agrees? %v\n", pass)
 	if follow != "" {
 		fmt.Printf("Follow-up: %s\n", follow)
 	}
 
-	_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
+	_ = r.EvaluateGates(db, []string{"clarity-form-1", "duplicate-1"})
 	for _, gr := range r.GateResults {
 		fmt.Printf("Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 	}

--- a/examples/project/main.go
+++ b/examples/project/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	PMFS "github.com/rjboer/PMFS"
-	llm "github.com/rjboer/PMFS/pmfs/llm"
 )
 
 func copyFile(src, dst string) error {
@@ -47,10 +46,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Project: %v", err)
 	}
-	prj.LLM = llm.DefaultClient
-	if err := db.Save(); err != nil {
-		log.Fatalf("Save: %v", err)
-	}
 
 	attDir := filepath.Join(dir, "products", "1", "projects", "1", "attachments", "1")
 	if err := os.MkdirAll(attDir, 0o755); err != nil {
@@ -71,13 +66,13 @@ func main() {
 	}
 	prj.D.Attachments = append(prj.D.Attachments, att)
 
-	if err := prj.D.Attachments[0].Analyze(prj); err != nil {
+	if err := prj.D.Attachments[0].Analyze(db, prj); err != nil {
 		log.Fatalf("Attachment Analyze: %v", err)
 	}
 
 	for i := range prj.D.PotentialRequirements {
 		r := &prj.D.PotentialRequirements[i]
-		pass, follow, err := r.Analyse(prj, "product_manager", "1")
+		pass, follow, err := r.Analyse(db, "product_manager", "1")
 		if err != nil {
 			log.Fatalf("Requirement Analyse: %v", err)
 		}
@@ -85,7 +80,7 @@ func main() {
 		if follow != "" {
 			fmt.Printf("  Follow-up: %s\n", follow)
 		}
-		if err := r.EvaluateGates(prj, []string{"clarity-form-1"}); err != nil {
+		if err := r.EvaluateGates(db, []string{"clarity-form-1"}); err != nil {
 			log.Fatalf("EvaluateGates: %v", err)
 		}
 		for _, gr := range r.GateResults {

--- a/requirement_suggest_test.go
+++ b/requirement_suggest_test.go
@@ -18,8 +18,8 @@ func TestRequirementSuggestOthers(t *testing.T) {
 		}
 		return mockResp, nil
 	}}
-	prj := &ProjectType{LLM: client}
-	reqs, err := r.SuggestOthers(prj)
+	db := &Database{LLM: client}
+	reqs, err := r.SuggestOthers(db)
 	if err != nil {
 		t.Fatalf("SuggestOthers: %v", err)
 	}
@@ -33,8 +33,8 @@ func TestRequirementSuggestOthersMalformed(t *testing.T) {
 	client := gemini.ClientFunc{AskFunc: func(prompt string) (string, error) {
 		return "not json", nil
 	}}
-	prj := &ProjectType{LLM: client}
-	if _, err := r.SuggestOthers(prj); err == nil {
+	db := &Database{LLM: client}
+	if _, err := r.SuggestOthers(db); err == nil {
 		t.Fatalf("expected error for malformed response")
 	}
 }


### PR DESCRIPTION
## Summary
- ensure `Database` holds the default LLM client and drop project-level client
- update requirement and attachment helpers to use the database's LLM
- document new database parameters for attachment ingestion helpers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0b353842c832b8c9a82f08aa4a510