### PR TITLE
Add Excel import for project data

### DIFF
--- a/excel.go
+++ b/excel.go
@@ -2,6 +2,7 @@ package PMFS
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -129,4 +130,153 @@ func (p *ProjectType) ExportExcel(path string) error {
 		return err
 	}
 	return nil
+}
+
+// ImportProjectExcel reads an Excel workbook and returns populated ProjectData.
+// It expects a sheet named "Project" with key/value pairs for basic metadata
+// and a "Requirements" sheet listing confirmed requirements. Additional
+// optional sheets like "PotentialRequirements" and "Intelligence" are imported
+// when present. Missing optional sheets are ignored.
+func ImportProjectExcel(path string) (*ProjectData, error) {
+	f, err := excelize.OpenFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var pd ProjectData
+
+	// Project metadata
+	rows, err := f.GetRows("Project")
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows[1:] {
+		if len(r) < 2 {
+			continue
+		}
+		key, val := r[0], r[1]
+		switch key {
+		case "Name":
+			pd.Name = val
+		case "Scope":
+			pd.Scope = val
+		case "StartDate":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, err
+			}
+			pd.StartDate = t
+		case "EndDate":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, err
+			}
+			pd.EndDate = t
+		case "Status":
+			pd.Status = val
+		case "Priority":
+			pd.Priority = val
+		}
+	}
+
+	// Requirements
+	reqRows, err := f.GetRows("Requirements")
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range reqRows[1:] {
+		if len(row) < 12 {
+			continue
+		}
+		var req Requirement
+		if req.ID, err = strconv.Atoi(row[0]); err != nil {
+			return nil, err
+		}
+		req.Name = row[1]
+		req.Description = row[2]
+		if req.Priority, err = strconv.Atoi(row[3]); err != nil {
+			return nil, err
+		}
+		if req.Level, err = strconv.Atoi(row[4]); err != nil {
+			return nil, err
+		}
+		req.User = row[5]
+		req.Status = row[6]
+		if req.CreatedAt, err = time.Parse(time.RFC3339, row[7]); err != nil {
+			return nil, err
+		}
+		if req.UpdatedAt, err = time.Parse(time.RFC3339, row[8]); err != nil {
+			return nil, err
+		}
+		if req.ParentID, err = strconv.Atoi(row[9]); err != nil {
+			return nil, err
+		}
+		req.Category = row[10]
+		if row[11] != "" {
+			req.Tags = strings.Split(row[11], ",")
+		}
+		pd.Requirements = append(pd.Requirements, req)
+	}
+
+	// Potential requirements (optional)
+	if prRows, err := f.GetRows("PotentialRequirements"); err == nil {
+		for _, row := range prRows[1:] {
+			if len(row) < 12 {
+				continue
+			}
+			var req Requirement
+			if req.ID, err = strconv.Atoi(row[0]); err != nil {
+				return nil, err
+			}
+			req.Name = row[1]
+			req.Description = row[2]
+			if req.Priority, err = strconv.Atoi(row[3]); err != nil {
+				return nil, err
+			}
+			if req.Level, err = strconv.Atoi(row[4]); err != nil {
+				return nil, err
+			}
+			req.User = row[5]
+			req.Status = row[6]
+			if req.CreatedAt, err = time.Parse(time.RFC3339, row[7]); err != nil {
+				return nil, err
+			}
+			if req.UpdatedAt, err = time.Parse(time.RFC3339, row[8]); err != nil {
+				return nil, err
+			}
+			if req.ParentID, err = strconv.Atoi(row[9]); err != nil {
+				return nil, err
+			}
+			req.Category = row[10]
+			if row[11] != "" {
+				req.Tags = strings.Split(row[11], ",")
+			}
+			pd.PotentialRequirements = append(pd.PotentialRequirements, req)
+		}
+	}
+
+	// Intelligence (optional)
+	if intelRows, err := f.GetRows("Intelligence"); err == nil {
+		for _, row := range intelRows[1:] {
+			if len(row) < 5 {
+				continue
+			}
+			var intel Intelligence
+			if intel.ID, err = strconv.Atoi(row[0]); err != nil {
+				return nil, err
+			}
+			intel.Filepath = row[1]
+			intel.Content = row[2]
+			intel.Description = row[3]
+			if intel.ExtractedAt, err = time.Parse(time.RFC3339, row[4]); err != nil {
+				return nil, err
+			}
+			pd.Intelligence = append(pd.Intelligence, intel)
+		}
+	}
+
+	return &pd, nil
 }


### PR DESCRIPTION
## Summary
- add `ImportProjectExcel` to load project metadata and related sheets from an Excel workbook

## Testing
- `go test ./...` *(fails: missing go.sum entry for github.com/xuri/excelize/v2)*
- `go mod tidy` *(fails: unable to access github.com/xuri/excelize/; CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6967cb0832b806769ce44ba410f