### PR TITLE
Use global database and add helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,22 +173,24 @@ go run ./examples/full
 
 ## Available Functions
 
-- `LoadSetup(path string) (*Database, error)`
+- `LoadSetup(path string) (*Database, error)` – initializes or creates the database at `path` and assigns it to the package-level `DB` variable
 
 - `(*Database) NewProduct(data ProductData) (int, error)`
 - `(*Database) ModifyProduct(data ProductData) (int, error)`
 - `(*Database) Save() error`
-- `(*ProductType) NewProject(db *Database, data ProjectData) (int, error)`
-- `(*ProductType) ModifyProject(db *Database, id int, data ProjectData) (int, error)`
+- `(*ProductType) NewProject(data ProjectData) (int, error)`
+- `(*ProductType) ModifyProject(id int, data ProjectData) (int, error)`
 - `(*ProductType) Project(id int) (*ProjectType, error)`
 - `(*ProjectType) Save() error`
 - `(*ProjectType) Load() error`
 
 - `(*ProductType) LoadProjects() error`
 - `(*Database) LoadAllProjects() error`
-- `(*ProjectType) IngestInputDir(db *Database, inputDir string) ([]Attachment, error)`
-- `(*ProjectType) AddAttachmentFromInput(db *Database, inputDir, filename string) (Attachment, error)`
-- `(*ProjectType) Attachments(db *Database) AttachmentManager`
+- `(*ProjectType) IngestInputDir(inputDir string) ([]Attachment, error)`
+- `(*ProjectType) AddAttachmentFromInput(inputDir, filename string) (Attachment, error)`
+- `(*ProjectType) AddAttachmentFromText(text string) (Attachment, error)`
+- `(*ProjectType) AddRequirement(r Requirement) error`
+- `(*ProjectType) Attachments() AttachmentManager`
 - `(*AttachmentManager) AddFromInputFolder() ([]Attachment, error)`
 - `FromGemini(req gemini.Requirement) Requirement`
 

--- a/attachments_manager.go
+++ b/attachments_manager.go
@@ -9,12 +9,11 @@ import (
 // AttachmentManager provides helper methods for managing attachments of a project.
 type AttachmentManager struct {
 	prj *ProjectType
-	db  *Database
 }
 
 // Attachments returns an AttachmentManager for this project.
-func (prj *ProjectType) Attachments(db *Database) AttachmentManager {
-	return AttachmentManager{prj: prj, db: db}
+func (prj *ProjectType) Attachments() AttachmentManager {
+	return AttachmentManager{prj: prj}
 }
 
 // AddFromInputFolder scans the project's default "input" directory and ingests
@@ -46,7 +45,7 @@ func (am AttachmentManager) AddFromInputFolder() ([]Attachment, error) {
 
 	ingested := make([]Attachment, 0, len(names))
 	for _, n := range names {
-		att, err := am.prj.AddAttachmentFromInput(am.db, inputDir, n)
+		att, err := am.prj.AddAttachmentFromInput(inputDir, n)
 		if err != nil {
 			return ingested, err
 		}

--- a/examples/analyse/main.go
+++ b/examples/analyse/main.go
@@ -10,14 +10,14 @@ import (
 // This example demonstrates analysing an attachment with a role-specific
 // question. Requires the GEMINI_API_KEY environment variable.
 func main() {
-	db, err := PMFS.LoadSetup(".")
+	_, err := PMFS.LoadSetup(".")
 	if err != nil {
 		log.Fatalf("LoadSetup: %v", err)
 	}
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
-	pass, follow, err := att.Analyse(db, "product_manager", "1", &prj)
+	pass, follow, err := att.Analyse("product_manager", "1", &prj)
 	if err != nil {
 		log.Fatalf("Analyse: %v", err)
 	}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -23,7 +23,7 @@ func main() {
 			log.Fatalf("add product: %v", err)
 		}
 		p := &db.Products[id-1]
-		if _, err := p.NewProject(db, PMFS.ProjectData{Name: "Example Project"}); err != nil {
+		if _, err := p.NewProject(PMFS.ProjectData{Name: "Example Project"}); err != nil {
 			log.Fatalf("add project: %v", err)
 		}
 	}

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -14,7 +14,7 @@ import (
 // the GEMINI_API_KEY environment variable.
 func main() {
 
-	db, err := PMFS.LoadSetup(".")
+	_, err := PMFS.LoadSetup(".")
 	if err != nil {
 		log.Fatalf("LoadSetup: %v", err)
 	}
@@ -23,7 +23,7 @@ func main() {
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.
-	if err := att.Analyze(db, &prj); err != nil {
+	if err := att.Analyze(&prj); err != nil {
 		log.Fatalf("analyze: %v", err)
 	}
 	if len(prj.D.PotentialRequirements) == 0 {
@@ -38,14 +38,14 @@ func main() {
 		fmt.Printf("Requirement %d: %s - %s\n", i+1, r.Name, r.Description)
 		id := strconv.Itoa(i + 1)
 		for _, role := range roles {
-			pass, follow, _ := r.Analyse(db, role, id)
+			pass, follow, _ := r.Analyse(role, id)
 			fmt.Printf("  %s agrees? %v\n", role, pass)
 			if follow != "" {
 				fmt.Printf("    Follow-up: %s\n", follow)
 			}
 		}
 
-		_ = r.EvaluateGates(db, []string{"clarity-form-1", "duplicate-1"})
+		_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
 		for _, gr := range r.GateResults {
 			fmt.Printf("  Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 		}

--- a/examples/full/main.go_old
+++ b/examples/full/main.go_old
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// Store the requirements in a project structure.
-	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
+	prj := PMFS.ProjectType{}
 	for _, r := range reqs {
 		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.FromGemini(r))
 	}
@@ -62,14 +62,14 @@ func main() {
 		fmt.Printf("Requirement %d: %s - %s\n", i+1, r.Name, r.Description)
 		id := strconv.Itoa(i + 1)
 		for _, role := range roles {
-			pass, follow, _ := r.Analyse(&prj, role, id)
+			pass, follow, _ := r.Analyse(role, id)
 			fmt.Printf("  %s agrees? %v\n", role, pass)
 			if follow != "" {
 				fmt.Printf("    Follow-up: %s\n", follow)
 			}
 		}
 
-		_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
+		_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
 		for _, gr := range r.GateResults {
 			fmt.Printf("  Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 		}

--- a/examples/gates/main.go
+++ b/examples/gates/main.go
@@ -10,13 +10,13 @@ import (
 // This example demonstrates evaluating a requirement against a gate. Requires
 // the GEMINI_API_KEY environment variable.
 func main() {
-	db, err := PMFS.LoadSetup(".")
+	_, err := PMFS.LoadSetup(".")
 	if err != nil {
 		log.Fatalf("LoadSetup: %v", err)
 	}
 	req := PMFS.Requirement{Description: "The system shall be user friendly."}
 
-	if err := req.EvaluateGates(db, []string{"clarity-form-1"}); err != nil {
+	if err := req.EvaluateGates([]string{"clarity-form-1"}); err != nil {
 
 		log.Fatalf("EvaluateGates: %v", err)
 	}

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -13,7 +13,7 @@ import (
 // variable.
 func main() {
 
-	db, err := PMFS.LoadSetup(".")
+	_, err := PMFS.LoadSetup(".")
 	if err != nil {
 		log.Fatalf("LoadSetup: %v", err)
 	}
@@ -22,7 +22,7 @@ func main() {
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
 	// Analyze a document to extract potential requirements.
-	if err := att.Analyze(db, &prj); err != nil {
+	if err := att.Analyze(&prj); err != nil {
 		log.Fatalf("analyze: %v", err)
 	}
 	if len(prj.D.PotentialRequirements) == 0 {
@@ -35,13 +35,13 @@ func main() {
 
 	// With the client configured above, the requirement can query roles and
 	// evaluate gates directly.
-	pass, follow, _ := r.Analyse(db, "qa_lead", "1")
+	pass, follow, _ := r.Analyse("qa_lead", "1")
 	fmt.Printf("QA Lead agrees? %v\n", pass)
 	if follow != "" {
 		fmt.Printf("Follow-up: %s\n", follow)
 	}
 
-	_ = r.EvaluateGates(db, []string{"clarity-form-1", "duplicate-1"})
+	_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
 	for _, gr := range r.GateResults {
 		fmt.Printf("Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 	}

--- a/examples/integration/main.go_old
+++ b/examples/integration/main.go_old
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Store the first requirement in a project structure.
-	prj := PMFS.ProjectType{LLM: llm.DefaultClient}
+	prj := PMFS.ProjectType{}
 
 	prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, PMFS.Requirement{
 		Name:        reqs[0].Name,
@@ -56,13 +56,13 @@ func main() {
 
 	// With the client configured above, the requirement can query roles and
 	// evaluate gates directly.
-	pass, follow, _ := r.Analyse(&prj, "qa_lead", "1")
+	pass, follow, _ := r.Analyse("qa_lead", "1")
 	fmt.Printf("QA Lead agrees? %v\n", pass)
 	if follow != "" {
 		fmt.Printf("Follow-up: %s\n", follow)
 	}
 
-	_ = r.EvaluateGates(&prj, []string{"clarity-form-1", "duplicate-1"})
+	_ = r.EvaluateGates([]string{"clarity-form-1", "duplicate-1"})
 	for _, gr := range r.GateResults {
 		fmt.Printf("Gate %s passed? %v\n", gr.Gate.ID, gr.Pass)
 	}

--- a/examples/program/main.go
+++ b/examples/program/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 	//attach a pointer to the products
 	p := &db.Products[id-1]
-	prjID, err := p.NewProject(db, PMFS.ProjectData{Name: "Demo Project"})
+	prjID, err := p.NewProject(PMFS.ProjectData{Name: "Demo Project"})
 	if err != nil {
 		log.Fatalf("NewProject: %v", err)
 	}
@@ -53,7 +53,7 @@ func main() {
 		log.Fatalf("Project: %v", err)
 	}
 
-	attDir := filepath.Join(dir, "products", "1", "projects", "1", "attachments", "1")
+	attDir := filepath.Join(path, "products", "1", "projects", "1", "attachments", "1")
 	if err := os.MkdirAll(attDir, 0o755); err != nil {
 		log.Fatalf("mkdir attDir: %v", err)
 	}
@@ -72,13 +72,13 @@ func main() {
 	}
 	prj.D.Attachments = append(prj.D.Attachments, att)
 
-	if err := prj.D.Attachments[0].Analyze(db, prj); err != nil {
+	if err := prj.D.Attachments[0].Analyze(prj); err != nil {
 		log.Fatalf("Attachment Analyze: %v", err)
 	}
 
 	for i := range prj.D.PotentialRequirements {
 		r := &prj.D.PotentialRequirements[i]
-		pass, follow, err := r.Analyse(db, "product_manager", "1")
+		pass, follow, err := r.Analyse("product_manager", "1")
 		if err != nil {
 			log.Fatalf("Requirement Analyse: %v", err)
 		}
@@ -86,7 +86,7 @@ func main() {
 		if follow != "" {
 			fmt.Printf("  Follow-up: %s\n", follow)
 		}
-		if err := r.EvaluateGates(db, []string{"clarity-form-1"}); err != nil {
+		if err := r.EvaluateGates([]string{"clarity-form-1"}); err != nil {
 			log.Fatalf("EvaluateGates: %v", err)
 		}
 		for _, gr := range r.GateResults {

--- a/examples/project/main.go
+++ b/examples/project/main.go
@@ -38,7 +38,7 @@ func main() {
 		log.Fatalf("NewProduct: %v", err)
 	}
 	p := &db.Products[id-1]
-	prjID, err := p.NewProject(db, PMFS.ProjectData{Name: "Demo Project"})
+	prjID, err := p.NewProject(PMFS.ProjectData{Name: "Demo Project"})
 	if err != nil {
 		log.Fatalf("NewProject: %v", err)
 	}
@@ -66,13 +66,13 @@ func main() {
 	}
 	prj.D.Attachments = append(prj.D.Attachments, att)
 
-	if err := prj.D.Attachments[0].Analyze(db, prj); err != nil {
+	if err := prj.D.Attachments[0].Analyze(prj); err != nil {
 		log.Fatalf("Attachment Analyze: %v", err)
 	}
 
 	for i := range prj.D.PotentialRequirements {
 		r := &prj.D.PotentialRequirements[i]
-		pass, follow, err := r.Analyse(db, "product_manager", "1")
+		pass, follow, err := r.Analyse("product_manager", "1")
 		if err != nil {
 			log.Fatalf("Requirement Analyse: %v", err)
 		}
@@ -80,7 +80,7 @@ func main() {
 		if follow != "" {
 			fmt.Printf("  Follow-up: %s\n", follow)
 		}
-		if err := r.EvaluateGates(db, []string{"clarity-form-1"}); err != nil {
+		if err := r.EvaluateGates([]string{"clarity-form-1"}); err != nil {
 			log.Fatalf("EvaluateGates: %v", err)
 		}
 		for _, gr := range r.GateResults {

--- a/pmfs/newproject.go
+++ b/pmfs/newproject.go
@@ -38,7 +38,7 @@ func NewProject(name string) (*ProjectType, error) {
 
 	prd := &db.Products[0]
 
-	id, err := prd.NewProject(db, PMFS.ProjectData{Name: name})
+	id, err := prd.NewProject(PMFS.ProjectData{Name: name})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- expose a package-level `DB` and remove explicit database parameters from project and requirement APIs
- allow adding attachments from plain text and append requirements via a helper
- update examples and tests to use the global database and `LoadSetup` for initialization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b20b8c3b28832b81413b9a7bfc8cb2