### PR TITLE
Load GEMINI_API_KEY from optional .env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
-	github.com/pelletier/go-toml/v2 v2.2.4
-	github.com/xuri/excelize/v2 v2.9.1
+        github.com/pelletier/go-toml/v2 v2.2.4
+        github.com/xuri/excelize/v2 v2.9.1
 )
 
 require (


### PR DESCRIPTION
## Summary
- add local .env loader and verify `GEMINI_API_KEY` before CLI starts
- document hierarchical product menu for easier navigation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b21ae80884832b9e25b3c07f5a0d91