### PR TITLE
Add project-wide analysis helper

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -892,3 +892,28 @@ func (prj *ProjectType) QualityControlScanALL(role, questionID string, gateIDs [
 	}
 	return nil
 }
+
+// AnalyseAll runs QualityControlAI on both confirmed and potential requirements.
+// It processes all requirements, returning the first error encountered, and
+// persists any gate evaluation results.
+func (prj *ProjectType) AnalyseAll(role, questionID string, gateIDs []string) error {
+	var firstErr error
+
+	for i := range prj.D.Requirements {
+		if _, _, err := prj.D.Requirements[i].QualityControlAI(role, questionID, gateIDs); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	for i := range prj.D.PotentialRequirements {
+		if _, _, err := prj.D.PotentialRequirements[i].QualityControlAI(role, questionID, gateIDs); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if err := prj.Save(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	return firstErr
+}

--- a/analyse_all_test.go
+++ b/analyse_all_test.go
@@ -1,0 +1,74 @@
+package PMFS
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	llm "github.com/rjboer/PMFS/pmfs/llm"
+	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+	"github.com/rjboer/PMFS/pmfs/llm/prompts"
+)
+
+type mockClient struct{}
+
+func (mockClient) AnalyzeAttachment(path string) ([]gemini.Requirement, error) { return nil, nil }
+
+func (mockClient) Ask(prompt string) (string, error) {
+	if strings.Contains(prompt, "fail") {
+		return "", errors.New("ask error")
+	}
+	return "Yes", nil
+}
+
+func TestAnalyseAll(t *testing.T) {
+	prompts.SetTestPrompts([]prompts.Prompt{{ID: "q1", Template: "%s"}})
+	defer prompts.SetTestPrompts(nil)
+
+	orig := llm.SetClient(mockClient{})
+	defer llm.SetClient(orig)
+
+	t.Setenv("GEMINI_API_KEY", "test-key")
+	dir := t.TempDir()
+	db, err := LoadSetup(dir)
+	if err != nil {
+		t.Fatalf("LoadSetup: %v", err)
+	}
+
+	if _, err := db.NewProduct(ProductData{Name: "prod"}); err != nil {
+		t.Fatalf("NewProduct: %v", err)
+	}
+	prd := &db.Products[0]
+	if _, err := prd.NewProject(ProjectData{Name: "prj"}); err != nil {
+		t.Fatalf("NewProject: %v", err)
+	}
+	prj := &prd.Projects[0]
+
+	prj.D.Requirements = []Requirement{{ID: 1, Description: "ok"}, {ID: 2, Description: "fail"}}
+	prj.D.PotentialRequirements = []Requirement{{ID: 1, Description: "pot"}}
+
+	err = prj.AnalyseAll("test", "q1", []string{"completeness-1"})
+	if err == nil || err.Error() != "ask error" {
+		t.Fatalf("expected ask error, got %v", err)
+	}
+
+	if len(prj.D.Requirements[0].GateResults) != 1 {
+		t.Fatalf("expected gate results for requirement")
+	}
+	if len(prj.D.PotentialRequirements[0].GateResults) != 1 {
+		t.Fatalf("expected gate results for potential requirement")
+	}
+
+	var prjReload ProjectType
+	prjReload.ID = prj.ID
+	prjReload.ProductID = prj.ProductID
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(prjReload.D.Requirements[0].GateResults) != 1 {
+		t.Fatalf("gate results not persisted")
+	}
+	if len(prjReload.D.PotentialRequirements[0].GateResults) != 1 {
+		t.Fatalf("potential gate results not persisted")
+	}
+}


### PR DESCRIPTION
## Summary
- add `AnalyseAll` method to run quality control across confirmed and potential requirements and persist results
- cover the helper with tests including gate evaluation and error aggregation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b37f09f184832b8432364fc0c011d4