### PR TITLE
Persist potential requirements on addition

### DIFF
--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -262,6 +262,13 @@ func TestAttachmentGenerateRequirements(t *testing.T) {
 	if len(prj.D.PotentialRequirements) != 1 || prj.D.PotentialRequirements[0].Name != "R1" {
 		t.Fatalf("unexpected potential requirements: %#v", prj.D.PotentialRequirements)
 	}
+	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(prjReload.D.PotentialRequirements) != 1 || prjReload.D.PotentialRequirements[0].Name != "R1" {
+		t.Fatalf("requirements not persisted: %#v", prjReload.D.PotentialRequirements)
+	}
 }
 
 func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {

--- a/examples/program/main.go
+++ b/examples/program/main.go
@@ -561,7 +561,7 @@ func suggestRelated(scanner *bufio.Scanner, prj *PMFS.ProjectType) {
 		return
 	}
 	req := &prj.D.Requirements[idx-1]
-	others, err := req.SuggestOthers()
+	others, err := req.SuggestOthers(prj)
 	if err != nil {
 		log.Printf("SuggestOthers: %v", err)
 		return

--- a/requirement_suggest_test.go
+++ b/requirement_suggest_test.go
@@ -24,12 +24,23 @@ func TestRequirementSuggestOthers(t *testing.T) {
 		t.Fatalf("LoadSetup: %v", err)
 	}
 	DB.LLM = client
-	reqs, err := r.SuggestOthers()
+	prj := &ProjectType{ProductID: 1, ID: 1}
+	reqs, err := r.SuggestOthers(prj)
 	if err != nil {
 		t.Fatalf("SuggestOthers: %v", err)
 	}
 	if len(reqs) != 2 || reqs[0].Name != "R2" || reqs[1].Description != "Desc3" {
 		t.Fatalf("unexpected reqs: %#v", reqs)
+	}
+	if len(prj.D.PotentialRequirements) != 2 {
+		t.Fatalf("requirements not appended: %#v", prj.D.PotentialRequirements)
+	}
+	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
+	if err := prjReload.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(prjReload.D.PotentialRequirements) != 2 {
+		t.Fatalf("requirements not persisted: %#v", prjReload.D.PotentialRequirements)
 	}
 }
 
@@ -44,7 +55,8 @@ func TestRequirementSuggestOthersMalformed(t *testing.T) {
 		t.Fatalf("LoadSetup: %v", err)
 	}
 	DB.LLM = client
-	if _, err := r.SuggestOthers(); err == nil {
+	prj := &ProjectType{ProductID: 1, ID: 1}
+	if _, err := r.SuggestOthers(prj); err == nil {
 		t.Fatalf("expected error for malformed response")
 	}
 }
@@ -61,11 +73,15 @@ func TestRequirementSuggestOthersCodeFence(t *testing.T) {
 		t.Fatalf("LoadSetup: %v", err)
 	}
 	DB.LLM = client
-	reqs, err := r.SuggestOthers()
+	prj := &ProjectType{ProductID: 1, ID: 1}
+	reqs, err := r.SuggestOthers(prj)
 	if err != nil {
 		t.Fatalf("SuggestOthers: %v", err)
 	}
 	if len(reqs) != 2 || reqs[0].Name != "R2" || reqs[1].Description != "Desc3" {
 		t.Fatalf("unexpected reqs: %#v", reqs)
+	}
+	if len(prj.D.PotentialRequirements) != 2 {
+		t.Fatalf("requirements not appended: %#v", prj.D.PotentialRequirements)
 	}
 }


### PR DESCRIPTION
## Summary
- Save suggested requirements directly to a project's potential list
- Persist generated requirements to disk immediately
- Adjust tests and examples for new SuggestOthers signature

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b411a051cc832ba853377d33c089bc