### PR TITLE
Persist potential requirements

### DIFF
--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -262,6 +262,16 @@ func TestAttachmentGenerateRequirements(t *testing.T) {
 	if len(prj.D.PotentialRequirements) != 1 || prj.D.PotentialRequirements[0].Name != "R1" {
 		t.Fatalf("unexpected potential requirements: %#v", prj.D.PotentialRequirements)
 	}
+	var dp struct {
+		D ProjectData `toml:"projectdata"`
+	}
+	p := filepath.Join(projectDir(prj.ProductID, prj.ID), projectTOML)
+	if err := readTOML(p, &dp); err != nil {
+		t.Fatalf("readTOML: %v", err)
+	}
+	if len(dp.D.PotentialRequirements) != 1 {
+		t.Fatalf("project.toml not updated: %#v", dp.D.PotentialRequirements)
+	}
 }
 
 func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {

--- a/examples/program/main.go
+++ b/examples/program/main.go
@@ -561,7 +561,7 @@ func suggestRelated(scanner *bufio.Scanner, prj *PMFS.ProjectType) {
 		return
 	}
 	req := &prj.D.Requirements[idx-1]
-	others, err := req.SuggestOthers()
+	others, err := req.SuggestOthers(prj)
 	if err != nil {
 		log.Printf("SuggestOthers: %v", err)
 		return


### PR DESCRIPTION
## Summary
- Save newly generated potential requirements to project.toml
- Append and persist requirement suggestions to the project model
- Extend tests and examples for persisted potential requirements

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b41e893628832b84229dc418fb9825