### PR TITLE
Add requirement template generation for design aspects

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -189,10 +189,10 @@ type Requirement struct {
 // Number of Belts
 // There are several ways to improve the requirement or add new one
 type DesignAspect struct {
-	Name                  string `json:"name" toml:"name"`
-	Description           string `json:"description" toml:"description"`
-	SuggestedRequirements []Requirement
-	Processed             bool `json:"AspectProcessed" toml:"AspectProcessed"` //the aspect has been processed
+	Name        string        `json:"name" toml:"name"`
+	Description string        `json:"description" toml:"description"`
+	Templates   []Requirement `json:"templates" toml:"templates"`
+	Processed   bool          `json:"AspectProcessed" toml:"AspectProcessed"` //the aspect has been processed
 }
 
 // FromGemini converts a Gemini requirement into a PMFS requirement.

--- a/design_aspect_llm.go
+++ b/design_aspect_llm.go
@@ -1,0 +1,43 @@
+package PMFS
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rjboer/PMFS/pmfs/llm/prompts"
+)
+
+// GenerateTemplates asks the LLM for requirement templates related to this
+// design aspect. Returned templates are appended to the aspect and also
+// returned to the caller.
+func (da *DesignAspect) GenerateTemplates(role, questionID string) ([]Requirement, error) {
+	ps, err := prompts.GetPrompts(role)
+	if err != nil {
+		return nil, err
+	}
+	var p *prompts.Prompt
+	for i := range ps {
+		if ps[i].ID == questionID {
+			p = &ps[i]
+			break
+		}
+	}
+	if p == nil {
+		return nil, fmt.Errorf("prompt %s/%s not found", role, questionID)
+	}
+	prompt := fmt.Sprintf(p.Template, da.Description)
+	resp, err := DB.LLM.Ask(prompt)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := parseLLMJSON(resp)
+	if err != nil {
+		return nil, err
+	}
+	var reqs []Requirement
+	if err := json.Unmarshal(raw, &reqs); err != nil {
+		return nil, err
+	}
+	da.Templates = append(da.Templates, reqs...)
+	return reqs, nil
+}


### PR DESCRIPTION
## Summary
- extend `DesignAspect` with a `Templates` slice to hold requirement templates
- add `GenerateTemplates` helper that queries the LLM for templates using role-based prompts
- remove obsolete `SuggestedRequirements` field and tag `Templates` for JSON/TOML serialization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd87b00ed4832b81670bf22e197736