### PR TITLE
feat: deduplicate requirements before persistence

### DIFF
--- a/deduplicate_test.go
+++ b/deduplicate_test.go
@@ -1,0 +1,25 @@
+package PMFS
+
+import (
+	"testing"
+
+	gemini "github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+func TestDeduplicate(t *testing.T) {
+	stub := gemini.ClientFunc{AskFunc: func(prompt string) (string, error) {
+		return "1", nil
+	}}
+	orig := DB
+	DB = &Database{LLM: stub}
+	defer func() { DB = orig }()
+
+	reqs := []Requirement{
+		{Name: "R1", Description: "System shall log in"},
+		{Name: "R1 copy", Description: "System shall log in"},
+	}
+	deduped := Deduplicate(reqs)
+	if len(deduped) != 1 {
+		t.Fatalf("expected 1 requirement, got %d", len(deduped))
+	}
+}

--- a/requirement_llm.go
+++ b/requirement_llm.go
@@ -22,8 +22,9 @@ func (r *Requirement) SuggestOthers(prj *ProjectType) ([]Requirement, error) {
 	if err := json.Unmarshal(raw, &reqs); err != nil {
 		return nil, err
 	}
+	reqs = Deduplicate(reqs)
 	if prj != nil {
-		prj.D.PotentialRequirements = append(prj.D.PotentialRequirements, reqs...)
+		prj.D.PotentialRequirements = Deduplicate(append(prj.D.PotentialRequirements, reqs...))
 		if err := prj.Save(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- add Deduplicate helper using lexical + LLM semantic checks
- run deduplication before storing potential requirements
- add unit test for deduplication

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bdc86c3970832b8a38f4d7f387b195