### PR TITLE
Add rate limiting and model configuration for LLM

### DIFF
--- a/llmconfig.json
+++ b/llmconfig.json
@@ -1,0 +1,4 @@
+{
+  "model": "gemini-1.5-flash-latest",
+  "requests_per_second": 3
+}

--- a/pmfs/llm/client.go
+++ b/pmfs/llm/client.go
@@ -13,9 +13,12 @@ type Client interface {
 }
 
 var (
-	// DefaultClient is the package's default LLM client.
-	DefaultClient Client = gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY"))
-	client        Client = DefaultClient
+	// DefaultClient is the package's default LLM client wrapped with a rate limiter.
+	DefaultClient Client = NewRateLimitedClient(
+		gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY"), config.Model),
+		config.RequestsPerSecond,
+	)
+	client Client = DefaultClient
 )
 
 // SetClient replaces the package's client, returning the previous one.

--- a/pmfs/llm/config.go
+++ b/pmfs/llm/config.go
@@ -1,0 +1,36 @@
+package llm
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+type Config struct {
+	Model             string `json:"model"`
+	RequestsPerSecond int    `json:"requests_per_second"`
+}
+
+func LoadConfig() Config {
+	cfg := Config{
+		Model:             gemini.DefaultModel,
+		RequestsPerSecond: 3,
+	}
+	if b, err := os.ReadFile("llmconfig.json"); err == nil {
+		_ = json.Unmarshal(b, &cfg)
+	}
+	if cfg.Model == "" {
+		cfg.Model = gemini.DefaultModel
+	}
+	if cfg.RequestsPerSecond <= 0 {
+		cfg.RequestsPerSecond = 3
+	}
+	return cfg
+}
+
+var config = LoadConfig()
+
+func Model() string { return config.Model }
+
+func RequestsPerSecond() int { return config.RequestsPerSecond }

--- a/pmfs/llm/gemini/gemini.go
+++ b/pmfs/llm/gemini/gemini.go
@@ -104,12 +104,15 @@ func Ask(prompt string) (string, error) {
 type RESTClient struct {
 	HTTPClient *http.Client
 	APIKey     string
+	Model      string
 }
 
-// NewRESTClient returns a RESTClient configured with the provided API key.
+const DefaultModel = "gemini-1.5-flash-latest"
+
+// NewRESTClient returns a RESTClient configured with the provided API key and model.
 // The HTTP client will be lazily initialized on first use.
-func NewRESTClient(apiKey string) Client {
-	return &RESTClient{APIKey: apiKey}
+func NewRESTClient(apiKey, model string) Client {
+	return &RESTClient{APIKey: apiKey, Model: model}
 }
 
 func (c *RESTClient) init() error {
@@ -121,6 +124,9 @@ func (c *RESTClient) init() error {
 		if c.APIKey == "" {
 			return errors.New("GEMINI_API_KEY not set")
 		}
+	}
+	if c.Model == "" {
+		c.Model = DefaultModel
 	}
 	return nil
 }
@@ -273,7 +279,7 @@ func (c *RESTClient) generate(body map[string]any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=%s", c.APIKey)
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", c.Model, c.APIKey)
 	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
 	if err != nil {
 		return "", err

--- a/pmfs/llm/ratelimit.go
+++ b/pmfs/llm/ratelimit.go
@@ -1,0 +1,34 @@
+package llm
+
+import (
+	"time"
+
+	"github.com/rjboer/PMFS/pmfs/llm/gemini"
+)
+
+type rateLimitedClient struct {
+	Client
+	tick <-chan time.Time
+}
+
+func NewRateLimitedClient(c Client, rps int) Client {
+	if rps <= 0 {
+		rps = 1
+	}
+	interval := time.Second / time.Duration(rps)
+	return &rateLimitedClient{Client: c, tick: time.Tick(interval)}
+}
+
+func (r *rateLimitedClient) wait() {
+	<-r.tick
+}
+
+func (r *rateLimitedClient) Ask(prompt string) (string, error) {
+	r.wait()
+	return r.Client.Ask(prompt)
+}
+
+func (r *rateLimitedClient) AnalyzeAttachment(path string) ([]gemini.Requirement, error) {
+	r.wait()
+	return r.Client.AnalyzeAttachment(path)
+}

--- a/pmfs/newproject.go
+++ b/pmfs/newproject.go
@@ -15,8 +15,8 @@ type ProjectType = PMFS.ProjectType
 // from the environment, and creates a new project with the provided name under
 // the first product (creating a default product if necessary).
 func NewProject(name string) (*ProjectType, error) {
-	// Ensure the default client uses the API key from the environment.
-	llm.SetClient(gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY")))
+	// Ensure the default client uses the API key and model from the environment/config.
+	llm.SetClient(gemini.NewRESTClient(os.Getenv("GEMINI_API_KEY"), llm.Model()))
 
 	dir := os.Getenv("PMFS_BASEDIR")
 	if dir == "" {


### PR DESCRIPTION
## Summary
- add simple time-based rate limiter wrapping LLM client
- load LLM model and rate limit settings from `llmconfig.json`
- allow Gemini REST client to accept configurable model

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bdf3514914832b959d9dd178a29b75