### PR TITLE
Introduce Condition and unify requirements

### DIFF
--- a/PMFS_test.go
+++ b/PMFS_test.go
@@ -289,11 +289,11 @@ func TestAttachmentGenerateRequirements(t *testing.T) {
 	if !ptr.Analyzed {
 		t.Fatalf("attachment not marked analyzed")
 	}
-	if len(prj.D.PotentialRequirements) != 1 || prj.D.PotentialRequirements[0].Name != "R1" {
-		t.Fatalf("unexpected potential requirements: %#v", prj.D.PotentialRequirements)
+	if len(prj.D.Requirements) != 1 || prj.D.Requirements[0].Name != "R1" {
+		t.Fatalf("unexpected requirements: %#v", prj.D.Requirements)
 	}
-	if prj.D.PotentialRequirements[0].AttachmentIndex != 0 {
-		t.Fatalf("attachment index not set: %#v", prj.D.PotentialRequirements[0])
+	if prj.D.Requirements[0].AttachmentIndex != 0 {
+		t.Fatalf("attachment index not set: %#v", prj.D.Requirements[0])
 	}
 	if len(prj.D.Intelligence) != 1 || prj.D.Intelligence[0].Description != "summary" {
 		t.Fatalf("intelligence not generated: %#v", prj.D.Intelligence)
@@ -309,11 +309,11 @@ func TestAttachmentGenerateRequirements(t *testing.T) {
 	if err := readTOML(p, &dp); err != nil {
 		t.Fatalf("readTOML: %v", err)
 	}
-	if len(dp.D.PotentialRequirements) != 1 {
-		t.Fatalf("project.toml not updated: %#v", dp.D.PotentialRequirements)
+	if len(dp.D.Requirements) != 1 {
+		t.Fatalf("project.toml not updated: %#v", dp.D.Requirements)
 	}
-	if dp.D.PotentialRequirements[0].AttachmentIndex != 0 {
-		t.Fatalf("attachment index not persisted: %#v", dp.D.PotentialRequirements[0])
+	if dp.D.Requirements[0].AttachmentIndex != 0 {
+		t.Fatalf("attachment index not persisted: %#v", dp.D.Requirements[0])
 	}
 	if len(dp.D.Intelligence) != 1 {
 		t.Fatalf("intelligence not persisted: %#v", dp.D.Intelligence)
@@ -394,28 +394,28 @@ func TestAddAttachmentAnalyzesAndAppendsRequirements(t *testing.T) {
 	if !att.Analyzed {
 		t.Fatalf("attachment not analyzed")
 	}
-	if len(prj.D.PotentialRequirements) != len(mockReqs) {
-		t.Fatalf("expected %d potential requirements, got %d", len(mockReqs), len(prj.D.PotentialRequirements))
+	if len(prj.D.Requirements) != len(mockReqs) {
+		t.Fatalf("expected %d requirements, got %d", len(mockReqs), len(prj.D.Requirements))
 	}
-	if prj.D.PotentialRequirements[0].Name != mockReqs[0].Name {
+	if prj.D.Requirements[0].Name != mockReqs[0].Name {
 		t.Fatalf("requirements not appended")
 	}
-	if prj.D.PotentialRequirements[0].AttachmentIndex != 0 {
-		t.Fatalf("attachment index not set: %#v", prj.D.PotentialRequirements[0])
+	if prj.D.Requirements[0].AttachmentIndex != 0 {
+		t.Fatalf("attachment index not set: %#v", prj.D.Requirements[0])
 	}
 	// ensure requirements persisted to disk
 	prjReload := ProjectType{ID: prj.ID, ProductID: prj.ProductID}
 	if err := prjReload.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(prjReload.D.PotentialRequirements) != len(mockReqs) {
-		t.Fatalf("expected %d persisted requirements, got %d", len(mockReqs), len(prjReload.D.PotentialRequirements))
+	if len(prjReload.D.Requirements) != len(mockReqs) {
+		t.Fatalf("expected %d persisted requirements, got %d", len(mockReqs), len(prjReload.D.Requirements))
 	}
-	if prjReload.D.PotentialRequirements[0].Name != mockReqs[0].Name {
-		t.Fatalf("requirements not persisted: %#v", prjReload.D.PotentialRequirements)
+	if prjReload.D.Requirements[0].Name != mockReqs[0].Name {
+		t.Fatalf("requirements not persisted: %#v", prjReload.D.Requirements)
 	}
-	if prjReload.D.PotentialRequirements[0].AttachmentIndex != 0 {
-		t.Fatalf("attachment index not persisted: %#v", prjReload.D.PotentialRequirements[0])
+	if prjReload.D.Requirements[0].AttachmentIndex != 0 {
+		t.Fatalf("attachment index not persisted: %#v", prjReload.D.Requirements[0])
 	}
 }
 
@@ -478,7 +478,7 @@ func TestAddAttachmentRealAPI(t *testing.T) {
 	if !att.Analyzed {
 		t.Fatalf("attachment not analyzed")
 	}
-	if len(prj.D.PotentialRequirements) == 0 {
+	if len(prj.D.Requirements) == 0 {
 		t.Fatalf("no requirements returned")
 	}
 
@@ -486,11 +486,11 @@ func TestAddAttachmentRealAPI(t *testing.T) {
 	if err := prjReload.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(prjReload.D.PotentialRequirements) == 0 {
-		t.Fatalf("requirements not persisted: %#v", prjReload.D.PotentialRequirements)
+	if len(prjReload.D.Requirements) == 0 {
+		t.Fatalf("requirements not persisted: %#v", prjReload.D.Requirements)
 	}
-	if prjReload.D.PotentialRequirements[0].Name == "" {
-		t.Fatalf("empty requirement name: %#v", prjReload.D.PotentialRequirements[0])
+	if prjReload.D.Requirements[0].Name == "" {
+		t.Fatalf("empty requirement name: %#v", prjReload.D.Requirements[0])
 	}
 }
 

--- a/analyse_all_test.go
+++ b/analyse_all_test.go
@@ -44,8 +44,7 @@ func TestAnalyseAll(t *testing.T) {
 	}
 	prj := &prd.Projects[0]
 
-	prj.D.Requirements = []Requirement{{ID: 1, Description: "ok"}, {ID: 2, Description: "fail"}}
-	prj.D.PotentialRequirements = []Requirement{{ID: 1, Description: "pot"}}
+	prj.D.Requirements = []Requirement{{ID: 1, Description: "ok"}, {ID: 2, Description: "fail"}, {ID: 3, Description: "pot"}}
 
 	err = prj.AnalyseAll("test", "q1", []string{"completeness-1"})
 	if err == nil || err.Error() != "ask error" {
@@ -55,8 +54,8 @@ func TestAnalyseAll(t *testing.T) {
 	if len(prj.D.Requirements[0].GateResults) != 1 {
 		t.Fatalf("expected gate results for requirement")
 	}
-	if len(prj.D.PotentialRequirements[0].GateResults) != 1 {
-		t.Fatalf("expected gate results for potential requirement")
+	if len(prj.D.Requirements[2].GateResults) != 1 {
+		t.Fatalf("expected gate results for third requirement")
 	}
 
 	var prjReload ProjectType
@@ -68,7 +67,7 @@ func TestAnalyseAll(t *testing.T) {
 	if len(prjReload.D.Requirements[0].GateResults) != 1 {
 		t.Fatalf("gate results not persisted")
 	}
-	if len(prjReload.D.PotentialRequirements[0].GateResults) != 1 {
-		t.Fatalf("potential gate results not persisted")
+	if len(prjReload.D.Requirements[2].GateResults) != 1 {
+		t.Fatalf("gate results for third requirement not persisted")
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ flowchart TD
     LLM --> X1[Create Intelligence & Design Aspects]
     X1 --> X2[Intelligence]
     X1 --> X3[Design Aspects]
-    LLM --> G[Project.PotentialRequirements]
+    LLM --> G[Project.Requirements]
     X2 --> G
     X3 --> X4[Generate requirements based on design aspects]
     X4 --> G

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -33,7 +33,6 @@ classDiagram
         +[]Requirement Requirements
         +[]Attachment Attachments
         +[]Intelligence Intelligence
-        +[]Requirement PotentialRequirements
         +bool FixedCategories
     }
 
@@ -54,6 +53,7 @@ classDiagram
         +[]DesignAspect DesignAspects
         +[]DesignAspect RecommendedChanges
         +[]gates.Result GateResults
+        +ConditionType Condition
         +[]Intelligence IntelligenceLink
         +[]string Tags
     }
@@ -78,6 +78,13 @@ classDiagram
         +time.Time Timestamp
         +string User
         +string Comment
+    }
+
+    class ConditionType {
+        +bool Proposed
+        +bool AIgenerated
+        +bool Active
+        +bool Deleted
     }
 
     class Intelligence {

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -22,19 +22,19 @@ func main() {
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
-	// Analyze a document to extract potential requirements.
+	// Analyze a document to extract requirements.
 	if err := att.Analyze(&prj); err != nil {
 		log.Fatalf("analyze: %v", err)
 	}
-	if len(prj.D.PotentialRequirements) == 0 {
+	if len(prj.D.Requirements) == 0 {
 		log.Fatal("no requirements returned")
 	}
 
 	roles := []string{"product_manager", "qa_lead", "security_privacy_officer"}
 
 	// Ask each role about every requirement and evaluate quality gates.
-	for i := range prj.D.PotentialRequirements {
-		r := &prj.D.PotentialRequirements[i]
+	for i := range prj.D.Requirements {
+		r := &prj.D.Requirements[i]
 		fmt.Printf("Requirement %d: %s - %s\n", i+1, r.Name, r.Description)
 		id := strconv.Itoa(i + 1)
 		for _, role := range roles {

--- a/examples/integration/main.go
+++ b/examples/integration/main.go
@@ -21,15 +21,15 @@ func main() {
 	prj := PMFS.ProjectType{ProductID: 0, ID: 0}
 	att := PMFS.Attachment{RelPath: "../../../testdata/spec1.txt"}
 
-	// Analyze a document to extract potential requirements.
+	// Analyze a document to extract requirements.
 	if err := att.Analyze(&prj); err != nil {
 		log.Fatalf("analyze: %v", err)
 	}
-	if len(prj.D.PotentialRequirements) == 0 {
+	if len(prj.D.Requirements) == 0 {
 		log.Fatal("no requirements returned")
 	}
 
-	r := &prj.D.PotentialRequirements[0]
+	r := &prj.D.Requirements[0]
 
 	fmt.Printf("Requirement: %s - %s\n", r.Name, r.Description)
 

--- a/examples/program/main.go
+++ b/examples/program/main.go
@@ -408,7 +408,6 @@ func importExcel(scanner *bufio.Scanner, p *PMFS.ProductType, prj **PMFS.Project
 		(*prj).D.Status = data.Status
 		(*prj).D.Priority = data.Priority
 		(*prj).D.Requirements = append((*prj).D.Requirements, data.Requirements...)
-		(*prj).D.PotentialRequirements = append((*prj).D.PotentialRequirements, data.PotentialRequirements...)
 		(*prj).D.Intelligence = append((*prj).D.Intelligence, data.Intelligence...)
 		fmt.Println("Merged Excel data into current project.")
 	}
@@ -494,7 +493,7 @@ func ingestAttachment(scanner *bufio.Scanner, prj *PMFS.ProjectType) {
 		return
 	}
 
-	before := len(prj.D.PotentialRequirements)
+	before := len(prj.D.Requirements)
 	if err := att.Analyze(prj); err != nil {
 		log.Printf("Analyze: %v", err)
 		return
@@ -502,7 +501,7 @@ func ingestAttachment(scanner *bufio.Scanner, prj *PMFS.ProjectType) {
 	if err := PMFS.DB.Save(); err != nil {
 		log.Printf("Save DB: %v", err)
 	}
-	newReqs := prj.D.PotentialRequirements[before:]
+	newReqs := prj.D.Requirements[before:]
 	if len(newReqs) == 0 {
 		fmt.Println("No new requirements suggested.")
 		return

--- a/examples/project/main.go
+++ b/examples/project/main.go
@@ -70,8 +70,8 @@ func main() {
 		log.Fatalf("Attachment Analyze: %v", err)
 	}
 
-	for i := range prj.D.PotentialRequirements {
-		r := &prj.D.PotentialRequirements[i]
+	for i := range prj.D.Requirements {
+		r := &prj.D.Requirements[i]
 		pass, follow, err := r.Analyse("product_manager", "1")
 		if err != nil {
 			log.Fatalf("Requirement Analyse: %v", err)

--- a/requirement_llm.go
+++ b/requirement_llm.go
@@ -36,7 +36,11 @@ func (r *Requirement) SuggestOthers(prj *ProjectType) ([]Requirement, error) {
 		reqs[i].ParentID = parentIdx
 	}
 	if prj != nil {
-		prj.D.PotentialRequirements = Deduplicate(append(prj.D.PotentialRequirements, reqs...))
+		for i := range reqs {
+			reqs[i].Condition.Proposed = true
+			reqs[i].Condition.AIgenerated = true
+		}
+		prj.D.Requirements = Deduplicate(append(prj.D.Requirements, reqs...))
 		if err := prj.Save(); err != nil {
 			return nil, err
 		}

--- a/requirement_suggest_test.go
+++ b/requirement_suggest_test.go
@@ -34,11 +34,11 @@ func TestRequirementSuggestOthers(t *testing.T) {
 	if len(reqs) != 2 || reqs[0].Name != "R2" || reqs[1].Description != "Desc3" {
 		t.Fatalf("unexpected reqs: %#v", reqs)
 	}
-	if len(prj.D.PotentialRequirements) != 2 {
-		t.Fatalf("requirements not appended: %#v", prj.D.PotentialRequirements)
+	if len(prj.D.Requirements) != 3 {
+		t.Fatalf("requirements not appended: %#v", prj.D.Requirements)
 	}
-	if reqs[0].ParentID != 0 || prj.D.PotentialRequirements[0].ParentID != 0 {
-		t.Fatalf("parent index not set: %#v", prj.D.PotentialRequirements[0])
+	if reqs[0].ParentID != 0 || prj.D.Requirements[1].ParentID != 0 {
+		t.Fatalf("parent index not set: %#v", prj.D.Requirements[1])
 	}
 	var dp struct {
 		D ProjectData `toml:"projectdata"`
@@ -47,8 +47,8 @@ func TestRequirementSuggestOthers(t *testing.T) {
 	if err := readTOML(path, &dp); err != nil {
 		t.Fatalf("readTOML: %v", err)
 	}
-	if len(dp.D.PotentialRequirements) != 2 {
-		t.Fatalf("project.toml not updated: %#v", dp.D.PotentialRequirements)
+	if len(dp.D.Requirements) != 3 {
+		t.Fatalf("project.toml not updated: %#v", dp.D.Requirements)
 
 	}
 }
@@ -95,11 +95,11 @@ func TestRequirementSuggestOthersCodeFence(t *testing.T) {
 	if len(reqs) != 2 || reqs[0].Name != "R2" || reqs[1].Description != "Desc3" {
 		t.Fatalf("unexpected reqs: %#v", reqs)
 	}
-	if len(prj.D.PotentialRequirements) != 2 {
-		t.Fatalf("requirements not appended: %#v", prj.D.PotentialRequirements)
+	if len(prj.D.Requirements) != 3 {
+		t.Fatalf("requirements not appended: %#v", prj.D.Requirements)
 	}
-	if prj.D.PotentialRequirements[0].ParentID != 0 {
-		t.Fatalf("parent index not set: %#v", prj.D.PotentialRequirements[0])
+	if prj.D.Requirements[1].ParentID != 0 {
+		t.Fatalf("parent index not set: %#v", prj.D.Requirements[1])
 	}
 
 	var dp2 struct {
@@ -109,8 +109,8 @@ func TestRequirementSuggestOthersCodeFence(t *testing.T) {
 	if err := readTOML(path, &dp2); err != nil {
 		t.Fatalf("readTOML: %v", err)
 	}
-	if len(dp2.D.PotentialRequirements) != 2 {
-		t.Fatalf("project.toml not updated: %#v", dp2.D.PotentialRequirements)
+	if len(dp2.D.Requirements) != 3 {
+		t.Fatalf("project.toml not updated: %#v", dp2.D.Requirements)
 	}
 
 }


### PR DESCRIPTION
## Summary
- add a ConditionType to track proposed, AI-generated, active, and deleted requirement states
- consolidate potential and active requirements into a single Requirements slice
- serialize requirement conditions in Excel and LLM suggestion flows

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68be074a26e4832b978bd9a61da56c12