### PR TITLE
Support requirement activation by ID and predicate

### DIFF
--- a/PMFS.go
+++ b/PMFS.go
@@ -1005,20 +1005,24 @@ func (prj *ProjectType) AddAttachmentFromText(text string) (Attachment, error) {
 	return *ptr, nil
 }
 
-// ActivateRequirement marks a requirement as active.
-func (prj *ProjectType) ActivateRequirement(idx int) {
-	if idx < 0 || idx >= len(prj.D.Requirements) {
-		return
+// ActivateRequirementByID activates the requirement with the given ID.
+// It sets Proposed to false and Active to true.
+func (prj *ProjectType) ActivateRequirementByID(id int) {
+	for i := range prj.D.Requirements {
+		if prj.D.Requirements[i].ID == id {
+			prj.D.Requirements[i].Condition.Proposed = false
+			prj.D.Requirements[i].Condition.Active = true
+			_ = prj.Save()
+			return
+		}
 	}
-	prj.D.Requirements[idx].Condition.Active = true
-	prj.D.Requirements[idx].Condition.Proposed = false
-	_ = prj.Save()
 }
 
-// ActivateAllPotential marks all proposed requirements as active.
-func (prj *ProjectType) ActivateAllPotential() {
+// ActivateRequirementsWhere activates all requirements for which pred returns true.
+// It toggles Proposed to false and Active to true for matches.
+func (prj *ProjectType) ActivateRequirementsWhere(pred func(Requirement) bool) {
 	for i := range prj.D.Requirements {
-		if prj.D.Requirements[i].Condition.Proposed {
+		if pred(prj.D.Requirements[i]) {
 			prj.D.Requirements[i].Condition.Proposed = false
 			prj.D.Requirements[i].Condition.Active = true
 		}

--- a/activate_requirement_test.go
+++ b/activate_requirement_test.go
@@ -1,0 +1,51 @@
+package PMFS
+
+import "testing"
+
+func TestActivateRequirementByID(t *testing.T) {
+	SetBaseDir(t.TempDir())
+	prj := &ProjectType{
+		ID:        1,
+		ProductID: 1,
+		D: ProjectData{
+			Requirements: []Requirement{
+				{ID: 1, Condition: ConditionType{Proposed: true}},
+				{ID: 2, Condition: ConditionType{Proposed: true}},
+			},
+		},
+	}
+	prj.ActivateRequirementByID(2)
+	if prj.D.Requirements[1].Condition.Proposed || !prj.D.Requirements[1].Condition.Active {
+		t.Fatalf("requirement not activated: %+v", prj.D.Requirements[1].Condition)
+	}
+	if !prj.D.Requirements[0].Condition.Proposed || prj.D.Requirements[0].Condition.Active {
+		t.Fatalf("unexpected change to requirement 1: %+v", prj.D.Requirements[0].Condition)
+	}
+}
+
+func TestActivateRequirementsWhere(t *testing.T) {
+	SetBaseDir(t.TempDir())
+	prj := &ProjectType{
+		ID:        1,
+		ProductID: 1,
+		D: ProjectData{
+			Requirements: []Requirement{
+				{ID: 1, Priority: 1, Condition: ConditionType{Proposed: true}},
+				{ID: 2, Priority: 2, Condition: ConditionType{Proposed: true}},
+				{ID: 3, Priority: 1, Condition: ConditionType{Proposed: true}},
+			},
+		},
+	}
+	prj.ActivateRequirementsWhere(func(r Requirement) bool {
+		return r.Priority == 1
+	})
+	if prj.D.Requirements[0].Condition.Proposed || !prj.D.Requirements[0].Condition.Active {
+		t.Fatalf("requirement 1 not activated: %+v", prj.D.Requirements[0].Condition)
+	}
+	if prj.D.Requirements[2].Condition.Proposed || !prj.D.Requirements[2].Condition.Active {
+		t.Fatalf("requirement 3 not activated: %+v", prj.D.Requirements[2].Condition)
+	}
+	if !prj.D.Requirements[1].Condition.Proposed || prj.D.Requirements[1].Condition.Active {
+		t.Fatalf("requirement 2 should remain proposed: %+v", prj.D.Requirements[1].Condition)
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ flowchart TD
 
   %% --- Requirement lifecycle ---
   subgraph "Requirement Workflow, assume we have a list of requirements"
-    G --> H[Project.ActivateRequirement]
+    G --> H[Project.ActivateRequirementByID]
     H --> I[list of Requirements]
     I --> J[Requirement.QualityControlAI]
     J --> LLM


### PR DESCRIPTION
## Summary
- replace ActivateRequirement and ActivateAllPotential with flexible helpers
- add ActivateRequirementByID and ActivateRequirementsWhere for targeted and batch activation
- update architecture docs and add tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be0e7c4c20832bbac149913a443501