### PR TITLE
docs: document requirement lifecycle with condition flags

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,16 +1,17 @@
 # PMFS Architecture Overview
 
-```mermaid
+PMFS maintains a single collection of requirements. Each requirement carries
+condition flags that describe its lifecycle state. The diagram below illustrates
+how artifacts are ingested and how requirements move through this lifecycle
+using these flags.
 
+```mermaid
 flowchart TD
 
   LLM[(LLM Service)]
   GATE[(Gates)]
 
-  %% --- Attachment ingestion ---
   subgraph Ingestion
-
-
     A[Add files to Input folder]
     A --> C[Project.AddAttachmentFromInput]
     C --> D[Attachment stored in folder + metadata]
@@ -19,43 +20,57 @@ flowchart TD
     LLM --> X1[Create Intelligence & Design Aspects]
     X1 --> X2[Intelligence]
     X1 --> X3[Design Aspects]
-    LLM --> G[Project.Requirements]
-    X2 --> G
+    LLM --> RP[Requirement (Proposed, AIgenerated)]
+    X2 --> RP
     X3 --> X4[Generate requirements based on design aspects]
-    X4 --> G
+    X4 --> RP
   end
 
-  %% --- Requirement lifecycle ---
-  subgraph "Requirement Workflow, assume we have a list of requirements"
-    G --> H[Project.ActivateRequirementByID]
-    H --> I[list of Requirements]
-    I --> J[Requirement.QualityControlAI]
+  subgraph "Requirement Lifecycle"
+    RP --> H[Project.ActivateRequirementByID]
+    H --> RA[Requirement (Active)]
+    RA --> J[Requirement.QualityControlAI]
     J --> LLM
     J --> GATE
     LLM --> J
     GATE --> J
     J --> K[Gate Results]
-    K --> I
-    I --> L[Requirement.GenerateDesignAspects]
+    K --> RA
+    RA --> L[Requirement.GenerateDesignAspects]
     L --> N[Design Aspects]
     N --> O[Generate requirements based on design aspects]
-    O --> G
-    I --> M[Requirement.SuggestOthers]
-    M --> G
-    G --> P[Deduplication of requirements]
-    H --> P
-
+    O --> RP
+    RA --> M[Requirement.SuggestOthers]
+    M --> RP
+    RA --> RD[Mark requirement Deleted]
+    RD --> RP
+    RP --> P[Deduplication of requirements]
   end
 
-  %% --- Persistence ---
-  G --> Q[Project.Save / Database.Save]
-  I --> Q
+  RP --> Q[Project.Save / Database.Save]
+  RA --> Q
 
-  %% --- Excel Import/Export ---
-  Q --> R[Project.ExportExcel]
-  R --> S[Excel Workbook]
+  Q --> R1[Project.ExportExcel]
+  R1 --> S[Excel Workbook]
   S --> T[ImportProjectExcel]
   T --> Q
 
 ```
+
+## Requirement Condition Flags
+
+- **Proposed** – candidate requirement awaiting activation. Proposed
+  requirements are skipped by analysis and gating.
+- **AIgenerated** – indicates the requirement originated from the LLM. User-created
+  requirements leave this false.
+- **Active** – requirement is approved and participates in analysis, gating, and
+  export.
+- **Deleted** – requirement has been removed from active consideration but is
+  retained for history and ignored by processing.
+
+### Typical transitions
+
+1. `Proposed` (often `AIgenerated`) → `Active` via activation.
+2. `Proposed` → `Deleted` when a candidate is discarded.
+3. `Active` → `Deleted` if an accepted requirement is later removed.
 

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -102,11 +102,11 @@ classDiagram
     ProjectData "1" --> "*" Requirement : requirements
     ProjectData "1" --> "*" Attachment : attachments
     ProjectData "1" --> "*" Intelligence : intelligence
-    ProjectData "1" --> "*" Requirement : potentialRequirements
     Requirement "1" --> "*" ChangeLog : history
     Requirement "1" --> "*" DesignAspect : designAspects
     Requirement "1" --> "*" DesignAspect : recommendedChanges
     Requirement "1" --> "*" Intelligence : intelligenceLink
+    Requirement "1" --> "1" ConditionType : condition
     DesignAspect "1" --> "*" Requirement : templates
     Intelligence "1" --> "*" DesignAspect : designAngles
 ```


### PR DESCRIPTION
## Summary
- remove PotentialRequirements from data model
- document ConditionType association on requirements
- refresh architecture with unified requirement flow and condition flag descriptions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be14e6dfd8832bb9e15cbe615530f8