### PR TITLE
feat: enhance deduplication

### DIFF
--- a/deduplicate_test.go
+++ b/deduplicate_test.go
@@ -15,9 +15,23 @@ func TestDeduplicate(t *testing.T) {
 	DB.LLM = gemini.ClientFunc{AskFunc: func(prompt string) (string, error) {
 		return "yes", nil
 	}}
-	reqs := []Requirement{{Name: "R1", Description: "same"}, {Name: "R2", Description: "same"}}
-	out := Deduplicate(reqs)
+	reqs := []Requirement{
+		{Name: "R1", Description: "same"},
+		{Name: "R2", Description: "same"},
+		{Name: "R3", Description: "same", Condition: ConditionType{Proposed: true}},
+		{Name: "R4", Description: "other", Condition: ConditionType{Deleted: true}},
+	}
+
+	out := Deduplicate(reqs, true)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 requirements when ignoring proposed, got %d", len(out))
+	}
+	if !out[1].Condition.Proposed {
+		t.Fatalf("expected proposed requirement to remain")
+	}
+
+	out = Deduplicate(reqs, false)
 	if len(out) != 1 {
-		t.Fatalf("expected 1 requirement, got %d", len(out))
+		t.Fatalf("expected 1 requirement when including proposed, got %d", len(out))
 	}
 }

--- a/requirement_llm.go
+++ b/requirement_llm.go
@@ -39,7 +39,7 @@ func (r *Requirement) SuggestOthers(prj *ProjectType) ([]Requirement, error) {
 		for i := range reqs {
 			reqs[i].Condition.Proposed = true
 		}
-		prj.D.Requirements = Deduplicate(append(prj.D.Requirements, reqs...))
+		prj.D.Requirements = Deduplicate(append(prj.D.Requirements, reqs...), false)
 		if err := prj.Save(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- skip deleted requirements during dedupe and optionally ignore proposed ones
- update dedupe call sites to pass unified requirements slice
- test dedupe behavior for proposed and deleted requirements

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be1878c6d8832baf3b981b99c26486