### PR TITLE
Track AI analysis state for requirements

### DIFF
--- a/analyse_all_test.go
+++ b/analyse_all_test.go
@@ -44,31 +44,38 @@ func TestAnalyseAll(t *testing.T) {
 	}
 	prj := &prd.Projects[0]
 
-	prj.D.Requirements = []Requirement{
-		{ID: 1, Description: "ok"},
-		{ID: 2, Description: "fail"},
-		{ID: 3, Description: "pot"},
-		{ID: 4, Description: "prop", Condition: ConditionType{Proposed: true}},
-		{ID: 5, Description: "del", Condition: ConditionType{Deleted: true}},
-	}
+       prj.D.Requirements = []Requirement{
+               {ID: 1, Description: "ok"},
+               {ID: 2, Description: "fail"},
+               {ID: 3, Description: "pot"},
+               {ID: 4, Description: "prop", Condition: ConditionType{Proposed: true}},
+               {ID: 5, Description: "del", Condition: ConditionType{Deleted: true}},
+               {ID: 6, Description: "done", Condition: ConditionType{AIanalyzed: true}},
+       }
 
 	err = prj.AnalyseAll("test", "q1", []string{"completeness-1"})
 	if err == nil || err.Error() != "ask error" {
 		t.Fatalf("expected ask error, got %v", err)
 	}
 
-	if len(prj.D.Requirements[0].GateResults) != 1 {
-		t.Fatalf("expected gate results for requirement")
-	}
-	if len(prj.D.Requirements[2].GateResults) != 1 {
-		t.Fatalf("expected gate results for third requirement")
-	}
-	if len(prj.D.Requirements[3].GateResults) != 0 {
-		t.Fatalf("proposed requirement should be skipped")
-	}
-	if len(prj.D.Requirements[4].GateResults) != 0 {
-		t.Fatalf("deleted requirement should be skipped")
-	}
+       if len(prj.D.Requirements[0].GateResults) != 1 {
+               t.Fatalf("expected gate results for requirement")
+       }
+       if len(prj.D.Requirements[2].GateResults) != 1 {
+               t.Fatalf("expected gate results for third requirement")
+       }
+       if len(prj.D.Requirements[3].GateResults) != 0 {
+               t.Fatalf("proposed requirement should be skipped")
+       }
+       if len(prj.D.Requirements[4].GateResults) != 0 {
+               t.Fatalf("deleted requirement should be skipped")
+       }
+       if len(prj.D.Requirements[5].GateResults) != 0 {
+               t.Fatalf("already analyzed requirement should be skipped")
+       }
+       if !prj.D.Requirements[0].Condition.AIanalyzed || !prj.D.Requirements[2].Condition.AIanalyzed {
+               t.Fatalf("requirements not marked analyzed")
+       }
 
 	var prjReload ProjectType
 	prjReload.ID = prj.ID
@@ -76,16 +83,22 @@ func TestAnalyseAll(t *testing.T) {
 	if err := prjReload.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(prjReload.D.Requirements[0].GateResults) != 1 {
-		t.Fatalf("gate results not persisted")
-	}
-	if len(prjReload.D.Requirements[2].GateResults) != 1 {
-		t.Fatalf("gate results for third requirement not persisted")
-	}
-	if len(prjReload.D.Requirements[3].GateResults) != 0 {
-		t.Fatalf("proposed requirement should not have persisted results")
-	}
-	if len(prjReload.D.Requirements[4].GateResults) != 0 {
-		t.Fatalf("deleted requirement should not have persisted results")
-	}
+       if len(prjReload.D.Requirements[0].GateResults) != 1 {
+               t.Fatalf("gate results not persisted")
+       }
+       if len(prjReload.D.Requirements[2].GateResults) != 1 {
+               t.Fatalf("gate results for third requirement not persisted")
+       }
+       if len(prjReload.D.Requirements[3].GateResults) != 0 {
+               t.Fatalf("proposed requirement should not have persisted results")
+       }
+       if len(prjReload.D.Requirements[4].GateResults) != 0 {
+               t.Fatalf("deleted requirement should not have persisted results")
+       }
+       if len(prjReload.D.Requirements[5].GateResults) != 0 {
+               t.Fatalf("already analyzed requirement should not have persisted results")
+       }
+       if !prjReload.D.Requirements[0].Condition.AIanalyzed || !prjReload.D.Requirements[2].Condition.AIanalyzed {
+               t.Fatalf("analyzed flag not persisted")
+       }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,8 @@ flowchart TD
   requirements are skipped by analysis and gating.
 - **AIgenerated** – indicates the requirement originated from the LLM. User-created
   requirements leave this false.
+- **AIanalyzed** – requirement has already been processed by the LLM and is
+  skipped during subsequent analyses.
 - **Active** – requirement is approved and participates in analysis, gating, and
   export.
 - **Deleted** – requirement has been removed from active consideration but is

--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -83,6 +83,7 @@ classDiagram
     class ConditionType {
         +bool Proposed
         +bool AIgenerated
+        +bool AIanalyzed
         +bool Active
         +bool Deleted
     }

--- a/excel.go
+++ b/excel.go
@@ -46,7 +46,7 @@ func (p *ProjectType) ExportExcel(path string) error {
 	if len(p.D.Requirements) > 0 {
 		sheet := "Requirements"
 		f.NewSheet(sheet)
-		header := []interface{}{"ID", "Name", "Description", "Priority", "Level", "User", "Status", "CreatedAt", "UpdatedAt", "ParentID", "AttachmentIndex", "Category", "Tags", "Proposed", "AIgenerated", "Active", "Deleted"}
+               header := []interface{}{"ID", "Name", "Description", "Priority", "Level", "User", "Status", "CreatedAt", "UpdatedAt", "ParentID", "AttachmentIndex", "Category", "Tags", "Proposed", "AIgenerated", "AIanalyzed", "Active", "Deleted"}
 		if err := f.SetSheetRow(sheet, "A1", &header); err != nil {
 			return err
 		}
@@ -65,10 +65,11 @@ func (p *ProjectType) ExportExcel(path string) error {
 				req.AttachmentIndex,
 				req.Category,
 				strings.Join(req.Tags, ","),
-				req.Condition.Proposed,
-				req.Condition.AIgenerated,
-				req.Condition.Active,
-				req.Condition.Deleted,
+                               req.Condition.Proposed,
+                               req.Condition.AIgenerated,
+                               req.Condition.AIanalyzed,
+                               req.Condition.Active,
+                               req.Condition.Deleted,
 			}
 			cell := fmt.Sprintf("A%d", i+2)
 			if err := f.SetSheetRow(sheet, cell, &row); err != nil {
@@ -195,24 +196,28 @@ func ImportProjectExcel(path string) (*ProjectData, error) {
 		if row[12] != "" {
 			req.Tags = strings.Split(row[12], ",")
 		}
-		if len(row) > 13 {
-			val := strings.ToLower(row[13])
-			req.Condition.Proposed = val == "true" || val == "1" || val == "yes"
-		}
-		if len(row) > 14 {
-			val := strings.ToLower(row[14])
-			req.Condition.AIgenerated = val == "true" || val == "1" || val == "yes"
-		}
-		if len(row) > 15 {
-			val := strings.ToLower(row[15])
-			req.Condition.Active = val == "true" || val == "1" || val == "yes"
-		}
-		if len(row) > 16 {
-			val := strings.ToLower(row[16])
-			req.Condition.Deleted = val == "true" || val == "1" || val == "yes"
-		}
-		pd.Requirements = append(pd.Requirements, req)
-	}
+               if len(row) > 13 {
+                       val := strings.ToLower(row[13])
+                       req.Condition.Proposed = val == "true" || val == "1" || val == "yes"
+               }
+               if len(row) > 14 {
+                       val := strings.ToLower(row[14])
+                       req.Condition.AIgenerated = val == "true" || val == "1" || val == "yes"
+               }
+               if len(row) > 15 {
+                       val := strings.ToLower(row[15])
+                       req.Condition.AIanalyzed = val == "true" || val == "1" || val == "yes"
+               }
+               if len(row) > 16 {
+                       val := strings.ToLower(row[16])
+                       req.Condition.Active = val == "true" || val == "1" || val == "yes"
+               }
+               if len(row) > 17 {
+                       val := strings.ToLower(row[17])
+                       req.Condition.Deleted = val == "true" || val == "1" || val == "yes"
+               }
+               pd.Requirements = append(pd.Requirements, req)
+       }
 
 	// Intelligence (optional)
 	if intelRows, err := f.GetRows("Intelligence"); err == nil {

--- a/excel_test.go
+++ b/excel_test.go
@@ -39,15 +39,15 @@ func TestExportRequirementsConditionColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRows: %v", err)
 	}
-	if len(rows) == 0 || len(rows[0]) < 17 {
-		t.Fatalf("expected condition columns in header, got %v", rows)
-	}
-	if rows[0][13] != "Proposed" || rows[0][14] != "AIgenerated" || rows[0][15] != "Active" || rows[0][16] != "Deleted" {
-		t.Fatalf("unexpected header %v", rows[0])
-	}
-	if len(rows) < 2 || len(rows[1]) < 17 || !strings.EqualFold(rows[1][13], "true") {
-		t.Fatalf("expected proposed true in row, got %v", rows[1])
-	}
+       if len(rows) == 0 || len(rows[0]) < 18 {
+               t.Fatalf("expected condition columns in header, got %v", rows)
+       }
+       if rows[0][13] != "Proposed" || rows[0][14] != "AIgenerated" || rows[0][15] != "AIanalyzed" || rows[0][16] != "Active" || rows[0][17] != "Deleted" {
+               t.Fatalf("unexpected header %v", rows[0])
+       }
+       if len(rows) < 2 || len(rows[1]) < 18 || !strings.EqualFold(rows[1][13], "true") {
+               t.Fatalf("expected proposed true in row, got %v", rows[1])
+       }
 }
 
 func TestImportRequirements(t *testing.T) {
@@ -64,11 +64,11 @@ func TestImportRequirements(t *testing.T) {
 	f.SetSheetName("Sheet1", "Project")
 
 	f.NewSheet("Requirements")
-	reqHeader := []interface{}{"ID", "Name", "Description", "Priority", "Level", "User", "Status", "CreatedAt", "UpdatedAt", "ParentID", "AttachmentIndex", "Category", "Tags", "Proposed", "AIgenerated", "Active", "Deleted"}
+       reqHeader := []interface{}{"ID", "Name", "Description", "Priority", "Level", "User", "Status", "CreatedAt", "UpdatedAt", "ParentID", "AttachmentIndex", "Category", "Tags", "Proposed", "AIgenerated", "AIanalyzed", "Active", "Deleted"}
 	if err := f.SetSheetRow("Requirements", "A1", &reqHeader); err != nil {
 		t.Fatalf("SetSheetRow: %v", err)
 	}
-	row := []interface{}{1, "Req", "desc", 1, 1, "u", "Status", time.Now().Format(time.RFC3339), time.Now().Format(time.RFC3339), 0, 0, "Cat", "tag", "true", "false", "false", "false"}
+       row := []interface{}{1, "Req", "desc", 1, 1, "u", "Status", time.Now().Format(time.RFC3339), time.Now().Format(time.RFC3339), 0, 0, "Cat", "tag", "true", "false", "false", "false", "false"}
 	if err := f.SetSheetRow("Requirements", "A2", &row); err != nil {
 		t.Fatalf("SetSheetRow: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add `AIanalyzed` flag to `ConditionType` to mark requirements already processed by AI
- skip and persist analysis when `AIanalyzed` is set and expose the flag in Excel import/export
- document the new flag and update tests

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68be06aae104832bb8a6cb611626090c