### PR TITLE
Serve webinterface index at root and path

### DIFF
--- a/examples/webinterface/main.go
+++ b/examples/webinterface/main.go
@@ -43,7 +43,7 @@ func main() {
 	s := &server{db: db, subs: make(map[int][]chan struct{})}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	indexHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := staticFS.ReadFile("index.html")
 		if err != nil {
 			http.Error(w, "index not found", http.StatusInternalServerError)
@@ -52,6 +52,8 @@ func main() {
 		w.Header().Set("Content-Type", "text/html")
 		w.Write(b)
 	})
+	mux.Handle("/", indexHandler)
+	mux.Handle("/examples/webinterface/", indexHandler)
 	mux.HandleFunc("/products", s.handleProducts)
 	mux.HandleFunc("/products/", s.handleProducts)
 	mux.HandleFunc("/projects/", s.handleProjects)


### PR DESCRIPTION
## Summary
- Route both `/` and `/examples/webinterface/` to the embedded `index.html` in the web interface example.

## Testing
- `go test ./...`
- `curl -s http://localhost:8080/ | head -n 5`
- `curl -s http://localhost:8080/examples/webinterface/ | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c5949134b4832baae7dc29ddf8ed81