### PR TITLE
Expose requirement activation endpoint with UI checkbox

### DIFF
--- a/examples/webinterface/index.html
+++ b/examples/webinterface/index.html
@@ -100,11 +100,18 @@ async function loadRequirements(){
     checkbox.type = 'checkbox';
     checkbox.checked = r.condition && r.condition.active;
     checkbox.onchange = async () => {
-      await fetch(`/projects/${pid}/requirements/${r.id}/active`, {
+      const res = await fetch(`/projects/${pid}/requirements/${r.id}/active`, {
         method: 'PUT',
         headers: {'Content-Type': 'application/json', 'X-Role': 'editor'},
         body: JSON.stringify({active: checkbox.checked})
       });
+      if(!res.ok){
+        const msg = await res.text();
+        alert(msg);
+        checkbox.checked = !checkbox.checked;
+        return;
+      }
+      await loadRequirements();
     };
     div.appendChild(checkbox);
     const label = document.createElement('span');

--- a/examples/webinterface/main.go
+++ b/examples/webinterface/main.go
@@ -672,27 +672,31 @@ func (s *server) handleRequirementsForProject(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if len(segs) == 2 && segs[1] == "active" {
-		if r.Method != http.MethodPut {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		var body struct {
-			Active bool `json:"active"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		req.Condition.Active = body.Active
-		if err := prj.Save(); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		s.notifySubscribers(prj.ID)
-		respondJSON(w, req)
+		s.handleRequirementActive(w, r, prj, req)
 		return
 	}
 	http.NotFound(w, r)
+}
+
+func (s *server) handleRequirementActive(w http.ResponseWriter, r *http.Request, prj *PMFS.ProjectType, req *PMFS.Requirement) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Active bool `json:"active"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.Condition.Active = body.Active
+	if err := prj.Save(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.notifySubscribers(prj.ID)
+	respondJSON(w, req)
 }
 
 // --------------------- Requirement-level endpoints --------------------------------


### PR DESCRIPTION
## Summary
- Allow toggling requirement `Condition.Active` via dedicated `/active` endpoint
- Add checkbox in web interface to flip active state and refresh list

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c59e5cd9c4832b96ac0148f9b00cb1